### PR TITLE
Remove nerf for the Your Eternal Reward in Mann versus Machine

### DIFF
--- a/src/game/shared/tf/tf_weapon_knife.cpp
+++ b/src/game/shared/tf/tf_weapon_knife.cpp
@@ -255,7 +255,7 @@ void CTFKnife::PrimaryAttack( void )
 		}
 
 		// We should very quickly disguise as our victim.
-		const float flDelay = ( bDropDisguise ) ? 1.5f : 0.2f;
+		const float flDelay = 0.2f;
 		SetContextThink( &CTFKnife::DisguiseOnKill, gpGlobals->curtime + flDelay, "DisguiseOnKill" );
 	}
 	else


### PR DESCRIPTION
### Related Issue
<!-- Number of the issue where this topic was mentioned -->
No issue has been opened
### Implementation
<!-- A clear and concise description of what the changes are -->
It has been standard in community MVM for years to remove the nerf to the YER, so now the disguise delay between backstabbing players and backstabbing robots has been made the same
### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 11 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
<!-- Any caveats and side effects of this PR -->
None

### Alternatives
<!-- Alternatives that were considered -->
Another possibility would be to remove all references of MVM from the YER's code, but I believe that community MVM only changes the disguise delay and not the automatic undisguise on line 254 of tf_weapon_knife.cpp