### PR TITLE
feat: Add bunnyhopping control CVars

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -77,6 +77,10 @@ ConVar tf_movement_lost_footing_restick( "tf_movement_lost_footing_restick", "50
 ConVar tf_movement_lost_footing_friction( "tf_movement_lost_footing_friction", "0.1", FCVAR_REPLICATED | FCVAR_CHEAT,
                                           "Ground friction for players who have lost their footing" );
 
+// Bunnyhopping related
+ConVar tf_restrict_bunnyhopping( "tf_restrict_bunnyhopping", "1", FCVAR_REPLICATED | FCVAR_CHEAT,"Restrict speed gain from bunnyhopping" );
+ConVar tf_automatic_bunnyhopping( "tf_automatic_bunnyhopping", "0", FCVAR_REPLICATED | FCVAR_CHEAT,"Automatically bunnyhop when holding jump" );
+
 extern ConVar cl_forwardspeed;
 extern ConVar cl_backspeed;
 extern ConVar cl_sidespeed;
@@ -1285,7 +1289,8 @@ bool CTFGameMovement::CheckJumpButton()
 		return false;
 
 	// Cannot jump again until the jump button has been released.
-	if ( mv->m_nOldButtons & IN_JUMP )
+	// Unless the automatic bunnyhopping cvar is enabled and the player is on the ground.
+	if ( mv->m_nOldButtons & IN_JUMP && (!tf_automatic_bunnyhopping.GetBool() || !bOnGround) )
 		return false;
 
 	// In air, so ignore jumps 
@@ -1312,7 +1317,12 @@ bool CTFGameMovement::CheckJumpButton()
 		return true;
 	}
 
-	PreventBunnyJumping();
+	// We restrict bunnyhopping by default, the same as base TF2.
+	// But now the cvar can now be used to disable this restriction.
+	if ( tf_restrict_bunnyhopping.GetBool() )
+	{
+		PreventBunnyJumping();
+	}
 
 	// Start jump animation and player sound (specific TF animation and flags).
 	m_pTFPlayer->DoAnimationEvent( PLAYERANIMEVENT_JUMP );


### PR DESCRIPTION
Introduce two new ConVars to control bunnyhopping behavior. They default to vanilla TF2 behavior, so no server is affected unless they explicitly opt-in. But for servers that want these controls, it enables clean, native configuration of movement mechanics without needing plugins or code changes.

### Implementation
This PR introduces two new ConVars to provide more granular control over bunnyhopping mechanics:

1. `tf_restrict_bunnyhopping`: Controls whether players can gain speed through consecutive jumps
   - Default: 1 (enabled)
   - Type: Boolean
   - Matches default TF2 behavior

2. `tf_automatic_bunnyhopping`: Enables automatic jumping while holding the jump button
   - Default: 0 (disabled)
   - Type: Boolean
   - Matches default TF2 behavior

The implementation modifies `CheckJumpButton()` in `src\game\shared\tf\tf_gamemovement.cpp` to check these ConVars before applying bunnyhopping mechanics. Both variables are registered with the FCVAR_CHEAT flag to maintain consistency with other movement-related ConVars. There could be some further discussion on if the CVars count as cheats.

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's Contributor License Agreement.
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `tc2-mod` branch.

Optional checklist:
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         | Client  | Server  | Version                    |
|---------|:-------:|:-------:|----------------------------|
| Windows | Built   | Built   | Windows 11 21H2           |


