### PR TITLE
Fix health overheal scaling

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.h
+++ b/src/game/client/tf/tf_hud_playerstatus.h
@@ -211,7 +211,7 @@ private:
 	int					m_iAnimState;
 	bool				m_bAnimate;
 
-	CPanelAnimationVar( int, m_nHealthBonusPosAdj, "HealthBonusPosAdj", "25" );
+	CPanelAnimationVarAliasType( float, m_nHealthBonusPosAdj, "HealthBonusPosAdj", "25", "proportional_float");
 	CPanelAnimationVar( float, m_flHealthDeathWarning, "HealthDeathWarning", "0.49" );
 	CPanelAnimationVar( Color, m_clrHealthDeathWarningColor, "HealthDeathWarningColor", "HUDDeathWarning" );
 

--- a/src/game/client/tf/tf_hud_playerstatus.h
+++ b/src/game/client/tf/tf_hud_playerstatus.h
@@ -211,7 +211,7 @@ private:
 	int					m_iAnimState;
 	bool				m_bAnimate;
 
-	CPanelAnimationVarAliasType( float, m_nHealthBonusPosAdj, "HealthBonusPosAdj", "25", "proportional_float");
+	CPanelAnimationVarAliasType( float, m_nHealthBonusPosAdj, "HealthBonusPosAdj", "25", "proportional_float" );
 	CPanelAnimationVar( float, m_flHealthDeathWarning, "HealthDeathWarning", "0.49" );
 	CPanelAnimationVar( Color, m_clrHealthDeathWarningColor, "HealthDeathWarningColor", "HUDDeathWarning" );
 


### PR DESCRIPTION
### Related Issue
https://github.com/ValveSoftware/Source-1-Games/issues/3811

### Implementation
Changes the type of m_nHealthBonusPosAdj from an int to proportional_float.

### Screenshots
![Healthoverhealscale Screenshot 2025 02 22 - 18 30 41 41](https://github.com/user-attachments/assets/62419d5b-7107-4e8e-84f8-eba20259d575)
![Healthoverhealscale Screenshot 2025 02 22 - 18 30 10 30](https://github.com/user-attachments/assets/1fb23045-28d9-4ac0-9f48-05d7d0030065)


### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | <!-- Built, Tested or N/A --> | Windows 11    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
<!-- Any caveats and side effects of this PR -->
TF2 huds that makes use of specific m_nHealthBonusPosAdj values may break.

### Alternatives
<!-- Alternatives that were considered -->