### PR TITLE
reduced the health size of the bonus overheal

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -768,7 +768,7 @@ void CTFHudPlayerHealth::SetHealth( int iNewHealth, int iMaxHealth, int	iMaxBuff
 
 				// scale the flashing image based on how much health bonus we currently have
 				float flBoostMaxAmount = ( iMaxBuffedHealth ) - m_nMaxHealth;
-				float flPercent = MIN( ( m_nHealth - m_nMaxHealth ) / flBoostMaxAmount, 1.0f );
+				float flPercent = MIN( ( m_nHealth - m_nMaxHealth ) / flBoostMaxAmount, 1.0f ) / 2;
 
 				int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
 				int nSizeAdj = 2 * nPosAdj;
@@ -801,7 +801,7 @@ void CTFHudPlayerHealth::SetHealth( int iNewHealth, int iMaxHealth, int	iMaxBuff
 
 				// scale the flashing image based on how much health bonus we currently have
 				float flBoostMaxAmount = m_nMaxHealth * m_flHealthDeathWarning;
-				float flPercent = ( flBoostMaxAmount - m_nHealth ) / flBoostMaxAmount;
+				float flPercent = (flBoostMaxAmount - m_nHealth) / flBoostMaxAmount / 2;
 
 				int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
 				int nSizeAdj = 2 * nPosAdj;


### PR DESCRIPTION
### Related Issue
<!-- Number of the issue where this topic was mentioned -->
incredible ajount of in-game complaining
### Implementation
<!-- A clear and concise description of what the changes are -->
I added the division operator to the lines of code that controll the size and put the operad as 2 
### Screenshots
<!-- Add screenshots if applicable -->
![Reducehealthoverhealsize Screenshot 2025 02 23 - 01 05 45 03](https://github.com/user-attachments/assets/5f452a89-226d-4e91-9442-be0df63c50c0)
![Reducehealthoverhealsize Screenshot 2025 02 23 - 01 05 37 69](https://github.com/user-attachments/assets/36745b46-0c86-4406-a8b2-641483a09388)

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | <!-- Built, Tested or N/A --> | Windows 3    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
<!-- Any caveats and side effects of this PR -->
This will break any huds that depended on the behavior of the last commit they will now be half sizse
### Alternatives
<!-- Alternatives that were considered -->
not doing this