### PR TITLE
Don't build Half-Life 2: Deathmatch

### DIFF
--- a/src/buildallprojects
+++ b/src/buildallprojects
@@ -28,7 +28,7 @@ fi
 solution_out="_vpc_/ninja/sdk_everything_$VPC_NINJA_BUILD_MODE"
 
 if [[ ! -e "$solution_out.ninja" ]]; then
-    devtools/bin/vpc /hl2mp /tf /linux64 /ninja /define:SOURCESDK +everything /mksln "$solution_out"
+    devtools/bin/vpc /tf /linux64 /ninja /define:SOURCESDK +everything /mksln "$solution_out"
 
     # Generate compile commands.
     ninja -f "$solution_out.ninja" -t compdb > compile_commands.json

--- a/src/createallprojects.bat
+++ b/src/createallprojects.bat
@@ -1,1 +1,1 @@
-devtools\bin\vpc.exe /hl2mp /tf /define:SOURCESDK +everything /mksln everything.sln
+devtools\bin\vpc.exe /tf /define:SOURCESDK +everything /mksln everything.sln


### PR DESCRIPTION
### Implementation
HL2DM is not shipped as part of comtress and wastes time and disk space for people wanting to build the project.

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [X] No other PRs implement this idea.
- [X] This PR does not introduce any regressions.
- [X] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [X] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [X] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [X] No other PRs address this.
- [X] This PR is as minimal as possible.
- [X] This PR does not introduce any regressions.
- [X] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 11 -->    |
|   Linux | Built & Tested | <!-- Built, Tested or N/A --> | 6.6.75 #1-NixOS SMP PREEMPT_DYNAMIC Sat Feb  1 17:37:57 UTC 2025 |

### Caveats
If in the future, a HL2DM version of comtress is created, it will have to be renabled

### Alternatives
Leave HL2DM enabled