### PR TITLE
Fix Vaccinator charge sounds playing multiple times per tick

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -1357,7 +1357,7 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 				}
 
 #ifdef CLIENT_DLL
-					if ( GetMedigunType() == MEDIGUN_RESIST )
+					if ( GetMedigunType() == MEDIGUN_RESIST && prediction->IsFirstTimePredicted() )
 					{
 						// Play a sound when we tick over to a new charge level
 						int nChargeLevel = int(floor(flNewLevel/flMinChargeAmount));


### PR DESCRIPTION
Due to prediction, the PrimaryAttack() function runs multiple times every tick. Every time the function runs on a tick where the player gains a charge, it will stack a copy of the sound that plays, which quickly becomes extremely loud. Commonly this will play 2 or 3, but in testing I've seen upwards of 7 or 8 playing at the same time.

This PR partially relies on #21, as prediction errors also can cause the charge to revert back to below the threshold for playing the sound, so this isn't a full fix unfortunately. I'm not sure how you would fix that to not cause issues when poor connection causes prediction errors.

### Related Issue
[Source-1-Games Issue 4479](https://github.com/ValveSoftware/Source-1-Games/issues/4479)

### Implementation
Add a `IsFirstTimePredicted()` check to the Vaccinator specific sound code, preventing it from playing on extra function calls used for prediction. Valve uses this function themselves twice in the medigun code alone to try and prevent some sound code from being run more than once.

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built & Tested | N/A | Windows 10 Home 22H2 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
Its possible that in an attempt to mitigate the issue Valve may have made the vaccinator charge noises quieter than they otherwise would've been, causing them to be pretty quiet in the instance that the bug was fixed. I have not tested if I think this is an issue, and I feel like it partially would be subjective anyway

### Alternatives
In the past I implemented a very poor bandaid fix involving a variable which was incremented when a new charge was gotten and decremented when one was used, preventing the sound from playing more than once for each charge. Comparatively it was over-complicated and did not fix the heart of the issue