### PR TITLE
Fix players entering enemy spawnrooms with partner taunts

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -21763,6 +21763,17 @@ CTFPlayer *CTFPlayer::FindPartnerTauntInitiator( void )
 			continue;
 		}
 
+		// Check if: 1. the initiator is inside a respawnroom and 2. the round has not ended, to not execute when players can already enter the enemy respawnroom
+		// This should be an easy way to fix players entering spawnrooms with partner taunts
+		if( PointInRespawnRoom( pPlayer, pPlayer->WorldSpaceCenter() ) && TFGameRules()->State_Get() != GR_STATE_TEAM_WIN)
+		{
+			if ( tf_highfive_debug.GetBool() )
+				Msg( " - but %s is inside their spawn room and the round hasn't ended.\n", pPlayer->GetPlayerName() );
+
+			//no trolling
+			continue;
+		}
+
 		// update to closer target player
 		if ( flDistSqrToPlayer < flDistSqrToTargetInitiator )
 		{


### PR DESCRIPTION
### Related Issue
https://github.com/ValveSoftware/Source-1-Games/issues/3881

### Implementation
This fix adds a check if the player that initiates the taunt is inside their respawnroom, and if the round hasn't ended yet, so that players can still taunt with enemies when they lose.

### Screenshots

https://github.com/user-attachments/assets/9ec27dbc-bf1a-4e20-aee0-c595077e60fb

https://github.com/user-attachments/assets/9bb3ec44-50df-4bc9-85ae-693bcfc00945

Of course, the other way doesn't make sense, and thus is allowed

https://github.com/user-attachments/assets/8cd9b7a5-1665-4bfb-bf13-acefe825fa73

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Yes | <!-- Built, Tested or N/A --> | Win10    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |