### PR TITLE
Fix ccache

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -8,12 +8,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup ccache
-        id: setup-ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
       - name: Setup Butler
         id: setup-butler
         run: |


### PR DESCRIPTION
### Implementation
The current action doesn't save the ccache cache directory more than once. This PR switches it to using an off the shelf action that always updates the cache.

moral of the story is `npm install left-pad`

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [X] No other PRs implement this idea.
- [X] This PR does not introduce any regressions.
- [X] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [X] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [X] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [X] No other PRs address this.
- [X] This PR is as minimal as possible.
- [X] This PR does not introduce any regressions.
- [X] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 11 -->    |
|   Linux | Built | <!-- Built, Tested or N/A --> | *Github Actions Runner* |
