### PR TITLE
Add subtick support

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -244,6 +244,7 @@ END_RECV_TABLE()
  		RecvPropFloat		( RECVINFO(m_vecVelocity[2]), 0, RecvProxy_LocalVelocityZ ),
 
 		RecvPropVector		( RECVINFO( m_vecBaseVelocity ) ),
+		RecvPropVector(RECVINFO(m_vecPreviouslyPreviouslyPredictedEyePosition)),
 
 		RecvPropEHandle		( RECVINFO( m_hConstraintEntity)),
 		RecvPropVector		( RECVINFO( m_vecConstraintCenter) ),
@@ -399,6 +400,7 @@ BEGIN_PREDICTION_DATA( C_BasePlayer )
 	// DEFINE_FIELD( m_pEnvironmentLight, dlight_t* ),
 	// DEFINE_FIELD( m_pBrightLight, dlight_t* ),
 	DEFINE_PRED_FIELD( m_hLastWeapon, FIELD_EHANDLE, FTYPEDESC_INSENDTABLE ),
+	DEFINE_PRED_FIELD(m_vecPreviouslyPreviouslyPredictedEyePosition, FIELD_POSITION_VECTOR, FTYPEDESC_INSENDTABLE),
 
 	DEFINE_PRED_FIELD( m_nTickBase, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
 

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -334,7 +334,10 @@ public:
 	float					GetDeathTime( void ) { return m_flDeathTime; }
 
 	void		SetPreviouslyPredictedOrigin( const Vector &vecAbsOrigin );
+	void		SetPreviouslyPreviouslyPredictedEyePosition(const Vector& vecAbsOrigin);
+
 	const Vector &GetPreviouslyPredictedOrigin() const;
+	const Vector& GetPreviouslyPreviouslyPredictedEyePosition() const;
 
 	// CS wants to allow small FOVs for zoomed-in AWPs.
 	virtual float GetMinFOV() const;
@@ -606,7 +609,8 @@ protected:
 	float m_flPredictionErrorTime;
 	
 	Vector m_vecPreviouslyPredictedOrigin; // Used to determine if non-gamemovement game code has teleported, or tweaked the player's origin
-
+	Vector m_vecPreviouslyPreviouslyPredictedEyePosition; // Used for attack interpolation
+	
 	char m_szLastPlaceName[MAX_PLACE_NAME_LENGTH];	// received from the server
 
 	// Texture names and surface data, used by CGameMovement
@@ -634,9 +638,6 @@ private:
 	bool m_bHasAttackInterpolationData = false;  // Whether we have valid data
 	float m_flAttackLerpTime = 1.0f;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
-	int m_nLastTickCount;               // The tick count from the last time we processed
-	Vector m_vecLastTickEyePosition;    // Eye position from the last tick
-	Vector m_vecCurrentTickEyePosition; // Current eye position for this tick
 
 	struct StepSoundCache_t
 	{

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -634,6 +634,9 @@ private:
 	bool m_bHasAttackInterpolationData;  // Whether we have valid data
 	float m_flAttackLerpTime;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
+	int m_nLastTickCount;               // The tick count from the last time we processed
+	Vector m_vecLastTickEyePosition;    // Eye position from the last tick
+	Vector m_vecCurrentTickEyePosition; // Current eye position for this tick
 
 	struct StepSoundCache_t
 	{

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -630,9 +630,9 @@ protected:
 
 private:
 	QAngle m_angAttackViewAngles;     // Stored view angles during attack
-	float m_flAttackInterpolationAmount; // Interpolation amount when attack was issued
-	bool m_bHasAttackInterpolationData;  // Whether we have valid data
-	float m_flAttackLerpTime;         // Calculated lerp time for the attack
+	float m_flAttackInterpolationAmount = 1.0f; // Interpolation amount when attack was issued
+	bool m_bHasAttackInterpolationData = false;  // Whether we have valid data
+	float m_flAttackLerpTime = 1.0f;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
 	int m_nLastTickCount;               // The tick count from the last time we processed
 	Vector m_vecLastTickEyePosition;    // Eye position from the last tick

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -399,7 +399,13 @@ public:
 	void					SetFiredWeapon( bool bFlag ) { m_bFiredWeapon = bFlag; }
 
 	virtual bool			CanUseFirstPersonCommand( void ){ return true; }
-	
+	void					SetAttackInterpolationData(const QAngle& viewAngles, float interpolationAmount);
+	void					GetAttackInterpolationData(QAngle& viewAngles, float& lerpTime);
+	bool					HasAttackInterpolationData() const;
+	void					ClearAttackInterpolationData();
+	void					SetInPostThink(bool inPostThink);
+	bool					IsInPostThink() const;
+	Vector					GetInterpolatedEyePosition();
 protected:
 	fogparams_t				m_CurrentFog;
 	EHANDLE					m_hOldFogController;
@@ -623,6 +629,11 @@ protected:
 #endif
 
 private:
+	QAngle m_angAttackViewAngles;     // Stored view angles during attack
+	float m_flAttackInterpolationAmount; // Interpolation amount when attack was issued
+	bool m_bHasAttackInterpolationData;  // Whether we have valid data
+	float m_flAttackLerpTime;         // Calculated lerp time for the attack
+	bool m_bInPostThink;              // Flag for post-think state
 
 	struct StepSoundCache_t
 	{

--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1315,7 +1315,7 @@ void CInput::CreateMove ( int sequence_number, float input_sample_frametime, boo
 		cmd->lerp_time = lerpTime;
 
 		// Fix movement commands for new viewangles
-		float deltaYaw = DEG2RAD(cmd->viewangles[YAW] - currentAngles[YAW]);
+		float deltaYaw = DEG2RAD(currentAngles[YAW] - cmd->viewangles[YAW]);
 		float s = sin(deltaYaw);
 		float c = cos(deltaYaw);
 

--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1315,7 +1315,7 @@ void CInput::CreateMove ( int sequence_number, float input_sample_frametime, boo
 		cmd->lerp_time = lerpTime;
 
 		// Fix movement commands for new viewangles
-		float deltaYaw = DEG2RAD(viewangles[YAW] - currentAngles[YAW]);
+		float deltaYaw = DEG2RAD(cmd->viewangles[YAW] - currentAngles[YAW]);
 		float s = sin(deltaYaw);
 		float c = cos(deltaYaw);
 

--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1332,7 +1332,7 @@ void CInput::CreateMove ( int sequence_number, float input_sample_frametime, boo
 	else {
 		cmd->lerp_time = 1.0f;
 	}
-
+	//Msg("CreateMove lerp_time was: %f\n", cmd->lerp_time);
 	HLTVCamera()->CreateMove( cmd );
 #if defined( REPLAY_ENABLED )
 	ReplayCamera()->CreateMove( cmd );

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -830,8 +830,14 @@ void CPrediction::RunPostThink( C_BasePlayer *player )
 #if !defined( NO_ENTITY_PREDICTION )
 	VPROF( "CPrediction::RunPostThink" );
 
+	// Mark that we're in post-think
+	player->SetInPostThink(true);
+
 	// Run post-think
 	player->PostThink();
+
+	// Clear post-think flag
+	player->SetInPostThink(false);
 #endif
 }
 

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -708,7 +708,6 @@ void CPrediction::FinishMove( C_BasePlayer *player, CUserCmd *ucmd, CMoveData *m
 	player->SetAbsVelocity( move->m_vecVelocity );
 
 	player->m_vecNetworkOrigin = move->GetAbsOrigin();
-	player->SetPreviouslyPreviouslyPredictedEyePosition(player->GetPreviouslyPreviouslyPredictedEyePosition());
 	player->SetPreviouslyPredictedOrigin( move->GetAbsOrigin() );
 	
 	player->m_Local.m_nOldButtons = move->m_nButtons;

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -618,7 +618,7 @@ void CPrediction::SetupMove( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper *
 	{
 		move->m_bGameCodeMovedPlayer = true;
 	}
-	
+	player->SetPreviouslyPreviouslyPredictedEyePosition(player->GetAbsOrigin() + player->GetViewOffset());
 	move->m_nPlayerHandle = player->GetClientHandle();
 	move->m_vecVelocity		= player->GetAbsVelocity();
 	move->SetAbsOrigin( player->GetNetworkOrigin() );
@@ -708,6 +708,7 @@ void CPrediction::FinishMove( C_BasePlayer *player, CUserCmd *ucmd, CMoveData *m
 	player->SetAbsVelocity( move->m_vecVelocity );
 
 	player->m_vecNetworkOrigin = move->GetAbsOrigin();
+	player->SetPreviouslyPreviouslyPredictedEyePosition(player->GetPreviouslyPreviouslyPredictedEyePosition());
 	player->SetPreviouslyPredictedOrigin( move->GetAbsOrigin() );
 	
 	player->m_Local.m_nOldButtons = move->m_nButtons;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -457,6 +457,7 @@ BEGIN_DATADESC( CBasePlayer )
 	DEFINE_FIELD( m_flForwardMove, FIELD_FLOAT ),
 	DEFINE_FIELD( m_flSideMove, FIELD_FLOAT ),
 	DEFINE_FIELD( m_vecPreviouslyPredictedOrigin, FIELD_POSITION_VECTOR ), 
+	DEFINE_FIELD(m_vecPreviouslyPreviouslyPredictedEyePosition, FIELD_POSITION_VECTOR),
 
 	DEFINE_FIELD( m_nNumCrateHudHints, FIELD_INTEGER ),
 
@@ -8159,6 +8160,7 @@ void SendProxy_CropFlagsToPlayerFlagBitsLength( const SendProp *pProp, const voi
 		SendPropFloat		( SENDINFO_VECTORELEM(m_vecVelocity, 2), 32, SPROP_NOSCALE|SPROP_CHANGES_OFTEN ),
 
 		SendPropVector		( SENDINFO( m_vecBaseVelocity ), 32, SPROP_NOSCALE ),
+		SendPropVector(SENDINFO(m_vecPreviouslyPreviouslyPredictedEyePosition), 32, SPROP_NOSCALE | SPROP_CHANGES_OFTEN),
 
 		SendPropEHandle		( SENDINFO( m_hConstraintEntity)),
 		SendPropVector		( SENDINFO( m_vecConstraintCenter), 0, SPROP_NOSCALE ),

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -1274,6 +1274,9 @@ private:
 	int m_nAttackButtons;             // Buttons pressed during attack
 	float m_flAttackLerpTime;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
+	int m_nLastTickCount;               // The tick count from the last time we processed
+	Vector m_vecLastTickEyePosition;    // Eye position from the last tick
+	Vector m_vecCurrentTickEyePosition; // Current eye position for this tick
 
 public:
 	virtual unsigned int PlayerSolidMask( bool brushOnly = false ) const;	// returns the solid mask for the given player, so bots can have a more-restrictive set

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -1269,10 +1269,9 @@ private:
 	// used to prevent achievement announcement spam
 	CUtlVector< float >		m_flAchievementTimes;
 	QAngle m_angAttackViewAngles;     // Stored view angles during attack
-	float m_flAttackInterpolationAmount; // Interpolation amount when attack was issued
-	bool m_bHasAttackInterpolationData;  // Whether we have valid data
-	int m_nAttackButtons;             // Buttons pressed during attack
-	float m_flAttackLerpTime;         // Calculated lerp time for the attack
+	float m_flAttackInterpolationAmount = 1.0f; // Interpolation amount when attack was issued
+	bool m_bHasAttackInterpolationData = false;  // Whether we have valid data
+	float m_flAttackLerpTime = 1.0f;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
 	int m_nLastTickCount;               // The tick count from the last time we processed
 	Vector m_vecLastTickEyePosition;    // Eye position from the last tick

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -844,7 +844,13 @@ public:
 	// How long since this player last interacted with something the game considers an objective/target/goal
 	float				GetTimeSinceLastObjective( void ) const { return ( m_flLastObjectiveTime == -1.f ) ? 999.f : gpGlobals->curtime - m_flLastObjectiveTime; }
 	void				SetLastObjectiveTime( float flTime ) { m_flLastObjectiveTime = flTime; }
-
+	void				SetAttackInterpolationData(const QAngle& viewAngles, float interpolationAmount);
+	void				GetAttackInterpolationData(QAngle& viewAngles, float& lerpTime);
+	bool				HasAttackInterpolationData() const;
+	void				ClearAttackInterpolationData();
+	void				SetInPostThink(bool inPostThink);
+	bool				IsInPostThink() const;
+	Vector					GetInterpolatedEyePosition();
 	// Used by gamemovement to check if the entity is stuck.
 	int m_StuckLast;
 	
@@ -1262,6 +1268,12 @@ private:
 
 	// used to prevent achievement announcement spam
 	CUtlVector< float >		m_flAchievementTimes;
+	QAngle m_angAttackViewAngles;     // Stored view angles during attack
+	float m_flAttackInterpolationAmount; // Interpolation amount when attack was issued
+	bool m_bHasAttackInterpolationData;  // Whether we have valid data
+	int m_nAttackButtons;             // Buttons pressed during attack
+	float m_flAttackLerpTime;         // Calculated lerp time for the attack
+	bool m_bInPostThink;              // Flag for post-think state
 
 public:
 	virtual unsigned int PlayerSolidMask( bool brushOnly = false ) const;	// returns the solid mask for the given player, so bots can have a more-restrictive set

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -914,7 +914,10 @@ public:
 	void		ClearZoomOwner( void );
 
 	void		SetPreviouslyPredictedOrigin( const Vector &vecAbsOrigin );
+	void		SetPreviouslyPreviouslyPredictedEyePosition(const Vector& vecAbsOrigin);
 	const Vector &GetPreviouslyPredictedOrigin() const;
+	const Vector& GetPreviouslyPreviouslyPredictedEyePosition() const;
+
 	float		GetFOVTime( void ){ return m_flFOVTime; }
 
 	void		AdjustDrownDmg( int nAmount );
@@ -1197,7 +1200,9 @@ protected:
 	int		m_nVehicleViewSavedFrame;	// Used to mark which frame was the last one the view was calculated for
 
 	Vector m_vecPreviouslyPredictedOrigin; // Used to determine if non-gamemovement game code has teleported, or tweaked the player's origin
+	CNetworkVar( Vector, m_vecPreviouslyPreviouslyPredictedEyePosition); // Used for attack interpolation
 	int		m_nBodyPitchPoseParam;
+
 
 	CNetworkString( m_szLastPlaceName, MAX_PLACE_NAME_LENGTH );
 
@@ -1273,9 +1278,6 @@ private:
 	bool m_bHasAttackInterpolationData = false;  // Whether we have valid data
 	float m_flAttackLerpTime = 1.0f;         // Calculated lerp time for the attack
 	bool m_bInPostThink;              // Flag for post-think state
-	int m_nLastTickCount;               // The tick count from the last time we processed
-	Vector m_vecLastTickEyePosition;    // Eye position from the last tick
-	Vector m_vecCurrentTickEyePosition; // Current eye position for this tick
 
 public:
 	virtual unsigned int PlayerSolidMask( bool brushOnly = false ) const;	// returns the solid mask for the given player, so bots can have a more-restrictive set

--- a/src/game/server/player_command.cpp
+++ b/src/game/server/player_command.cpp
@@ -141,7 +141,7 @@ void CPlayerMove::SetupMove( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper *p
 	{
 		move->m_bGameCodeMovedPlayer = true;
 	}
-
+	player->SetPreviouslyPreviouslyPredictedEyePosition(player->GetAbsOrigin() + player->GetViewOffset());
 	// Prepare the usercmd fields
 	move->m_nImpulseCommand		= ucmd->impulse;	
 	move->m_vecViewAngles		= ucmd->viewangles;

--- a/src/game/server/player_command.cpp
+++ b/src/game/server/player_command.cpp
@@ -300,8 +300,14 @@ void CPlayerMove::RunPostThink( CBasePlayer *player )
 {
 	VPROF( "CPlayerMove::RunPostThink" );
 
+	// Mark that we're in post-think
+	player->SetInPostThink(true);
 	// Run post-think
 	player->PostThink();
+
+	// Clear post-think flag
+	player->SetInPostThink(false);
+	player->ClearAttackInterpolationData();
 }
 
 void CommentarySystem_PePlayerRunCommand( CBasePlayer *player, CUserCmd *ucmd );
@@ -446,7 +452,7 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	VPROF_SCOPE_BEGIN( "moveHelper->ProcessImpacts" );
 	moveHelper->ProcessImpacts();
 	VPROF_SCOPE_END();
-
+	player->SetAttackInterpolationData(ucmd->viewangles, ucmd->lerp_time);
 	RunPostThink( player );
 
 	g_pGameMovement->FinishTrackPredictionErrors( player );

--- a/src/game/server/player_command.cpp
+++ b/src/game/server/player_command.cpp
@@ -452,6 +452,7 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	VPROF_SCOPE_BEGIN( "moveHelper->ProcessImpacts" );
 	moveHelper->ProcessImpacts();
 	VPROF_SCOPE_END();
+	//Msg("CPlayerMove::RunCommand lerp_time was: %f\n", ucmd->lerp_time);
 	player->SetAttackInterpolationData(ucmd->viewangles, ucmd->lerp_time);
 	RunPostThink( player );
 

--- a/src/game/server/player_lagcompensation.cpp
+++ b/src/game/server/player_lagcompensation.cpp
@@ -342,41 +342,51 @@ void CLagCompensationManager::FrameUpdatePostEntityThink()
 }
 
 // Called during player movement to set up/restore after lag compensation
-void CLagCompensationManager::StartLagCompensation(CBasePlayer* player, CUserCmd* cmd)
+void CLagCompensationManager::StartLagCompensation( CBasePlayer *player, CUserCmd *cmd )
 {
-	Assert(!m_isCurrentlyDoingCompensation);
+	Assert( !m_isCurrentlyDoingCompensation );
+
 	//DONT LAG COMP AGAIN THIS FRAME IF THERES ALREADY ONE IN PROGRESS
 	//IF YOU'RE HITTING THIS THEN IT MEANS THERES A CODE BUG
-	if (m_pCurrentPlayer)
+	if ( m_pCurrentPlayer )
 	{
-		Assert(m_pCurrentPlayer == NULL);
-		Warning("Trying to start a new lag compensation session while one is already active!\n");
+		Assert( m_pCurrentPlayer == NULL );
+		Warning( "Trying to start a new lag compensation session while one is already active!\n" );
 		return;
 	}
+
 	// Assume no players need to be restored
 	m_RestorePlayer.ClearAll();
 	m_bNeedToRestore = false;
+
 	m_pCurrentPlayer = player;
-	if (!player->m_bLagCompensation        // Player not wanting lag compensation
-		|| (gpGlobals->maxClients <= 1)    // no lag compensation in single player
-		|| !sv_unlag.GetBool()             // disabled by server admin
-		|| player->IsBot()                 // not for bots
-		|| player->IsObserver()            // not for spectators
+	
+	if ( !player->m_bLagCompensation		// Player not wanting lag compensation
+		 || (gpGlobals->maxClients <= 1)	// no lag compensation in single player
+		 || !sv_unlag.GetBool()				// disabled by server admin
+		 || player->IsBot() 				// not for bots
+		 || player->IsObserver()			// not for spectators
 		)
 		return;
+
 	// NOTE: Put this here so that it won't show up in single player mode.
-	VPROF_BUDGET("StartLagCompensation", VPROF_BUDGETGROUP_OTHER_NETWORKING);
-	Q_memset(m_RestoreData, 0, sizeof(m_RestoreData));
-	Q_memset(m_ChangeData, 0, sizeof(m_ChangeData));
+	VPROF_BUDGET( "StartLagCompensation", VPROF_BUDGETGROUP_OTHER_NETWORKING );
+	Q_memset( m_RestoreData, 0, sizeof( m_RestoreData ) );
+	Q_memset( m_ChangeData, 0, sizeof( m_ChangeData ) );
+
 	m_isCurrentlyDoingCompensation = true;
+
 	// Get true latency
-	// correct is the amount of time we have to correct game time
+
+	// correct is the amout of time we have to correct game time
 	float correct = 0.0f;
-	INetChannelInfo* nci = engine->GetPlayerNetInfo(player->entindex());
-	if (nci)
+
+	INetChannelInfo *nci = engine->GetPlayerNetInfo( player->entindex() ); 
+
+	if ( nci )
 	{
 		// add network latency
-		correct += nci->GetLatency(FLOW_OUTGOING);
+		correct+= nci->GetLatency( FLOW_OUTGOING );
 	}
 
 	// add view interpolation latency directly using player's lerp time
@@ -394,31 +404,37 @@ void CLagCompensationManager::StartLagCompensation(CBasePlayer* player, CUserCmd
 	// correct tick send by player 
 	int targettick = cmd->tick_count - TIME_TO_TICKS(player->m_fLerpTime);
 	// calc difference between tick send by player and our latency based tick
-	float deltaTime = correct - TICKS_TO_TIME(gpGlobals->tickcount - targettick);
-	if (fabs(deltaTime) > 0.2f)
+	float deltaTime =  correct - TICKS_TO_TIME(gpGlobals->tickcount - targettick);
+
+	if ( fabs( deltaTime ) > 0.2f )
 	{
 		// difference between cmd time and latency is too big > 200ms, use time correction based on latency
-		targettick = gpGlobals->tickcount - TIME_TO_TICKS(correct);
+		// DevMsg("StartLagCompensation: delta too big (%.3f)\n", deltaTime );
+		targettick = gpGlobals->tickcount - TIME_TO_TICKS( correct );
 	}
 	// Add the interpolation amount
 	float targettime = TICKS_TO_TIME(targettick) + extraTime;
 	// Iterate all active players
-	const CBitVec<MAX_EDICTS>* pEntityTransmitBits = engine->GetEntityTransmitBitsForClient(player->entindex() - 1);
-	for (int i = 1; i <= gpGlobals->maxClients; i++)
+	const CBitVec<MAX_EDICTS> *pEntityTransmitBits = engine->GetEntityTransmitBitsForClient( player->entindex() - 1 );
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 	{
-		CBasePlayer* pPlayer = UTIL_PlayerByIndex(i);
-		if (!pPlayer)
+		CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
+
+		if ( !pPlayer )
 		{
 			continue;
 		}
+
 		// Don't lag compensate yourself you loser...
-		if (player == pPlayer)
+		if ( player == pPlayer )
 		{
 			continue;
 		}
+
 		// Custom checks for if things should lag compensate (based on things like what team the player is on).
-		if (!player->WantsLagCompensationOnEntity(pPlayer, cmd, pEntityTransmitBits))
+		if ( !player->WantsLagCompensationOnEntity( pPlayer, cmd, pEntityTransmitBits ) )
 			continue;
+
 		// Move other player back in time
 		BacktrackPlayer(pPlayer, targettime);
 	}

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -2136,7 +2136,6 @@ bool CBasePlayer::IsInPostThink() const
 {
 	return m_bInPostThink;
 }
-
 Vector CBasePlayer::GetInterpolatedEyePosition()
 {
 	if (!IsInPostThink() || !HasAttackInterpolationData())
@@ -2169,5 +2168,34 @@ Vector CBasePlayer::GetInterpolatedEyePosition()
 	m_vecCurrentTickEyePosition = currentEyePosition;
 
 	// Interpolate between the last tick's position and the current position
-	return m_vecLastTickEyePosition + (m_vecCurrentTickEyePosition - m_vecLastTickEyePosition) * m_flAttackLerpTime;
+	Vector interpolatedPosition = m_vecLastTickEyePosition + (m_vecCurrentTickEyePosition - m_vecLastTickEyePosition) * m_flAttackLerpTime;
+
+	// Calculate the distance between interpolated position and regular eye position
+	float distance = (interpolatedPosition - currentEyePosition).Length();
+
+	// Log the distance using Msg()
+	//Msg("Interpolated eye position distance from regular eye position: %.3f units, m_flAttackLerpTime: %f\n", distance, m_flAttackLerpTime);
+
+	return interpolatedPosition;
 }
+/*
+Vector CBasePlayer::GetInterpolatedEyePosition()
+{
+	if (!IsInPostThink() || !HasAttackInterpolationData())
+		return EyePosition();
+
+	int currentTickCount = gpGlobals->tickcount;
+	SetInPostThink(false);
+	Vector currentEyePosition = EyePosition();
+	SetInPostThink(true);
+
+	Vector interpolatedPosition = (GetPreviouslyPredictedOrigin() + GetViewOffset()) + (currentEyePosition - (GetPreviouslyPredictedOrigin() + GetViewOffset())) * m_flAttackLerpTime;
+
+	// Calculate the distance between interpolated position and regular eye position
+	float distance = (interpolatedPosition - currentEyePosition).Length();
+
+	// Log the distance using Msg()
+	Msg("Interpolated eye position distance from regular eye position: %.3f units, m_flAttackLerpTime: %f\n", distance, m_flAttackLerpTime);
+
+	return interpolatedPosition;
+}*/

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -2148,9 +2148,10 @@ bool CBasePlayer::IsInPostThink() const
 }
 Vector CBasePlayer::GetInterpolatedEyePosition()
 {
+	bool wasInPostThink = IsInPostThink();
 	SetInPostThink(false);
 	Vector currentEyePosition = EyePosition();
-	SetInPostThink(true);
+	SetInPostThink(wasInPostThink);
 	
 	if (!IsInPostThink() || !HasAttackInterpolationData()) {
 		return currentEyePosition;

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -2148,12 +2148,13 @@ bool CBasePlayer::IsInPostThink() const
 }
 Vector CBasePlayer::GetInterpolatedEyePosition()
 {
-	if (!IsInPostThink() || !HasAttackInterpolationData())
-		return EyePosition();
-
 	SetInPostThink(false);
 	Vector currentEyePosition = EyePosition();
 	SetInPostThink(true);
+	
+	if (!IsInPostThink() || !HasAttackInterpolationData()) {
+		return currentEyePosition;
+	}
 
 	// Interpolate between the last tick's position and the current position
 	Vector interpolatedPosition = GetPreviouslyPreviouslyPredictedEyePosition() + (currentEyePosition - GetPreviouslyPreviouslyPredictedEyePosition()) * m_flAttackLerpTime;

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -336,7 +336,7 @@ Vector CBasePlayer::EyePosition()
 		return GetInterpolatedEyePosition();
 	}
 
-	if (GetVehicle() != NULL)
+	if ( GetVehicle() != NULL )
 	{
 		// Return the cached result
 		CacheVehicleView();
@@ -345,11 +345,11 @@ Vector CBasePlayer::EyePosition()
 	else
 	{
 #ifdef CLIENT_DLL
-		if (IsObserver())
+		if ( IsObserver() )
 		{
-			if (GetObserverMode() == OBS_MODE_CHASE || GetObserverMode() == OBS_MODE_POI)
+			if ( GetObserverMode() == OBS_MODE_CHASE || GetObserverMode() == OBS_MODE_POI )
 			{
-				if (IsLocalPlayer())
+				if ( IsLocalPlayer() )
 				{
 					return MainViewOrigin();
 				}

--- a/src/game/shared/tf/tf_item_inventory.cpp
+++ b/src/game/shared/tf/tf_item_inventory.cpp
@@ -964,7 +964,7 @@ void CTFPlayerInventory::LoadLocalLoadout()
 					m_LoadoutItems[iClass][iSlot] = uItemId;
 
 					CEconItemView *pItem = GetInventoryItemByItemID(uItemId);
-					if (pItem) {
+					if (pItem && pItem->GetSOCData()) {
 						pItem->GetSOCData()->Equip(iClass, iSlot);
 					}
 				}

--- a/src/game/shared/usercmd.cpp
+++ b/src/game/shared/usercmd.cpp
@@ -169,6 +169,7 @@ void WriteUsercmd( bf_write *buf, const CUserCmd *to, const CUserCmd *from )
 		buf->WriteOneBit( 0 );
 	}
 
+
 #if defined( HL2_CLIENT_DLL )
 	if ( to->entitygroundcontact.Count() != 0 )
 	{
@@ -187,6 +188,16 @@ void WriteUsercmd( bf_write *buf, const CUserCmd *to, const CUserCmd *from )
 		buf->WriteOneBit( 0 );
 	}
 #endif
+
+	if (to->lerp_time != from->lerp_time)
+	{
+		buf->WriteOneBit(1);
+		buf->WriteFloat(to->lerp_time);
+	}
+	else
+	{
+		buf->WriteOneBit(0);
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -289,6 +300,7 @@ void ReadUsercmd( bf_read *buf, CUserCmd *move, CUserCmd *from )
 		move->mousedy = buf->ReadShort();
 	}
 
+
 #if defined( HL2_DLL )
 	if ( buf->ReadOneBit() )
 	{
@@ -303,4 +315,8 @@ void ReadUsercmd( bf_read *buf, CUserCmd *move, CUserCmd *from )
 		}
 	}
 #endif
+	if (buf->ReadOneBit())
+	{
+		move->lerp_time = buf->ReadFloat();
+	}
 }

--- a/src/game/shared/usercmd.h
+++ b/src/game/shared/usercmd.h
@@ -56,7 +56,7 @@ public:
 #endif
 		mousedx = 0;
 		mousedy = 0;
-
+		lerp_time = 1.0f;
 		hasbeenpredicted = false;
 #if defined( HL2_DLL ) || defined( HL2_CLIENT_DLL )
 		entitygroundcontact.RemoveAll();
@@ -84,7 +84,7 @@ public:
 #endif
 		mousedx				= src.mousedx;
 		mousedy				= src.mousedy;
-
+		lerp_time = src.lerp_time;
 		hasbeenpredicted	= src.hasbeenpredicted;
 
 #if defined( HL2_DLL ) || defined( HL2_CLIENT_DLL )

--- a/src/game/shared/usercmd.h
+++ b/src/game/shared/usercmd.h
@@ -171,7 +171,8 @@ public:
 #if defined( HL2_DLL ) || defined( HL2_CLIENT_DLL )
 	CUtlVector< CEntityGroundContact > entitygroundcontact;
 #endif
-
+	// Attack lerp time
+	double lerp_time;
 };
 
 void ReadUsercmd( bf_read *buf, CUserCmd *move, CUserCmd *from );


### PR DESCRIPTION
### Related Issue
N/A

### Implementation
Add subtick support (like CS:2) by sending the interpolation amount in the UserCmd (lerp_pos) whenever an attack occurs between ticks.

### Screenshots
N/A

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | Tested | Windows 10    |
|   Linux | N/A | N/A | <!-- `uname -vr` output --> |

### Caveats
Code probably needs to be cleaned up a lot
Probably breaks demo compatibility
In theory might break bots but I didn't notice any difference

### Alternatives
Porting the game to Source 2 (DMCA)