### PR TITLE
Fix floating health bars not rendering for giant robots in MvM

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--
+Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
+1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
+1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
+1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
+1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
+2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
+2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
+2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
+2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
+-->
+
+# Description

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -72,7 +72,7 @@ void DisableFloatingHealthCallback( IConVar *var, const char *oldString, float o
 ConVar tf_hud_target_id_disable_floating_health( "tf_hud_target_id_disable_floating_health", "0", FCVAR_ARCHIVE, "Set to disable floating health bar", DisableFloatingHealthCallback );
 ConVar tf_hud_target_id_alpha( "tf_hud_target_id_alpha", "100", FCVAR_ARCHIVE, "Alpha value of target id background, default 100" );
 ConVar tf_hud_target_id_offset( "tf_hud_target_id_offset", "0", FCVAR_ARCHIVE, "RES file Y offset for target id" );
-ConVar tf_hud_target_id_show_avatars( "tf_hud_target_id_show_avatars", "2", FCVAR_ARCHIVE, "Display Steam avatars on TargetID when using floating health icons.  1 = everyone, 2 = friends only." );
+ConVar tf_hud_target_id_show_avatars( "tf_hud_target_id_show_avatars", "1", FCVAR_ARCHIVE, "Display Steam avatars on TargetID when using floating health icons.  1 = everyone, 2 = friends only." );
 
 
 bool ShouldHealthBarBeVisible( CBaseEntity *pTarget, CTFPlayer *pLocalPlayer )

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -80,12 +80,14 @@ bool ShouldHealthBarBeVisible( CBaseEntity *pTarget, CTFPlayer *pLocalPlayer )
 	if ( !pTarget || !pLocalPlayer )
 		return false;
 
-	if ( tf_hud_target_id_disable_floating_health.GetBool() )
-		return false;
-
+	// now second in priority to force floating health bars on for giant robots in MvM, robot destruction NPCs, and any custom game logic that forces the mini boss flag on players
+	// regardless of setting due to entities that return this check as true typically not having a visible target ID to fall back to when tf_hud_target_id_disable_floating_health is 1.
 	if ( pTarget->IsHealthBarVisible() )
 		return true;
 
+	if ( tf_hud_target_id_disable_floating_health.GetBool() )
+		return false;
+	
 	if ( !pTarget->IsPlayer() )
 		return false;
 


### PR DESCRIPTION
This introduces a QoL change where if tf_hud_target_id_disable_floating_health is 1, it will still display the health bars for entities that do not have a visible target ID to fall back to, such as enemy mini bosses (aka giant robots in MvM) and robot destruction bots. Before this fix, having floating health bars disabled would result in you being unable to view the health of giant robots whereas you normally should be able to.
