### PR TITLE
Fix extended range hits behind a ConVar

### DIFF
--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -271,25 +271,6 @@ void CTFSword::WeaponReset( void )
 }
 
 //-----------------------------------------------------------------------------
-// Purpose:
-//-----------------------------------------------------------------------------
-int	CTFSword::GetSwingRange( void )
-{
-	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( pOwner && pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
-	{
-		return 128;
-	}
-	else
-	{
-		//int iRange = 0;
-		//CALL_ATTRIB_HOOK_INT( iRange, is_a_sword )
-		//return 72;
-		return 72;
-	}
-}
-
-//-----------------------------------------------------------------------------
 // Purpose: A speed mod that is applied even if the weapon isn't in hand.
 //-----------------------------------------------------------------------------
 float CTFSword::GetSwordSpeedMod( void )

--- a/src/game/shared/tf/tf_weapon_sword.h
+++ b/src/game/shared/tf/tf_weapon_sword.h
@@ -88,7 +88,6 @@ public:
 	virtual void		WeaponReset( void );
 	virtual float		GetSwordSpeedMod( void );
 	virtual int			GetSwordHealthMod();
-	virtual int			GetSwingRange( void );
 	virtual void		OnDecapitation( CTFPlayer *pDeadPlayer );
 	
 	virtual bool		Deploy( void );

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -50,6 +50,8 @@ END_DATADESC()
 ConVar tf_meleeattackforcescale( "tf_meleeattackforcescale", "80.0", FCVAR_CHEAT | FCVAR_GAMEDLL | FCVAR_DEVELOPMENTONLY );
 #endif
 
+ConVar tf_demoextendedrangefix("tf_demoextendedrangefix", "0", FCVAR_CHEAT | FCVAR_REPLICATED | FCVAR_NOTIFY, "Enable the possibly unintended fix for Demoknight's shield extending the range of swords");
+
 #ifdef _DEBUG
 extern ConVar tf_weapon_criticals_force_random;
 #endif // _DEBUG
@@ -78,6 +80,7 @@ void CTFWeaponBaseMelee::WeaponReset( void )
 	m_flSmackTime = -1.0f;
 	m_bConnected = false;
 	m_bMiniCrit = false;
+	m_bWasCharging = false;
 }
 
 // -----------------------------------------------------------------------------
@@ -139,6 +142,7 @@ void CTFWeaponBaseMelee::Spawn()
 // -----------------------------------------------------------------------------
 bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 {
+	m_bWasCharging = false; // Once we holster, remove the charge hit extension
 	m_flSmackTime = -1.0f;
 	if ( GetPlayerOwner() )
 	{
@@ -163,9 +167,10 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
-	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( pOwner && pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+ 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
+	if ( pOwner && (pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || (tf_demoextendedrangefix.GetBool() && m_bWasCharging)) )
 	{
+		m_bWasCharging = false;
 		return 128;
 	}
 	else
@@ -174,6 +179,7 @@ int	CTFWeaponBaseMelee::GetSwingRange( void )
 		CALL_ATTRIB_HOOK_INT( iIsSword, is_a_sword )
 		if ( iIsSword )
 		{
+			__debugbreak();
 			return 72; // swords are typically 72
 		}
 		return 48;
@@ -198,6 +204,7 @@ void CTFWeaponBaseMelee::PrimaryAttack()
 	m_iWeaponMode = TF_WEAPON_PRIMARY_MODE;
 	m_bConnected = false;
 
+	m_bWasCharging = pPlayer->m_Shared.InCond(TF_COND_SHIELD_CHARGE);
 	pPlayer->EndClassSpecialSkill();
 
 	// Swing the weapon.

--- a/src/game/shared/tf/tf_weaponbase_melee.h
+++ b/src/game/shared/tf/tf_weaponbase_melee.h
@@ -92,6 +92,7 @@ protected:
 	float	m_flSmackTime;
 	bool	m_bConnected;
 	bool	m_bMiniCrit;
+	bool 	m_bWasCharging;
 
 #ifdef GAME_DLL
 	CUtlVector< CHandle< CTFPlayer > > m_potentialVictimVector;


### PR DESCRIPTION
### Related Issue
<!-- Number of the issue where this topic was mentioned -->
None

### Implementation
<!-- A clear and concise description of what the changes are -->
Very simply changes a few things:
- Makes a new ConVar that holds if we should fix the "broken" extended hits of demoknight
- Tracks when the player charges, and stores it
- When the player swings their sword, check the ConVar `tf_demoextendedrangefix`, if it is anything other than `0`, enable the fix

This puts this technically balance change behind a "default-false" convar

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions. (We only do things if `tf_demoextendedrangefix` is set)
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 11 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
<!-- Any caveats and side effects of this PR -->

### Alternatives
<!-- Alternatives that were considered -->
