### PR TITLE
Various projectile, visual, and mechanical changes to improve consistency and QoL.

### DIFF
--- a/src/game/client/c_baseviewmodel.cpp
+++ b/src/game/client/c_baseviewmodel.cpp
@@ -213,6 +213,7 @@ bool C_BaseViewModel::ShouldFlipViewModel()
 	{
 		return pWeapon->m_bFlipViewModel != cl_flipviewmodels.GetBool();
 	}
+	return cl_flipviewmodels.GetBool(); // hack for scout ball projeciles to have properly flipped viewmodels
 #endif
 
 	return false;

--- a/src/game/client/tf/tf_hud_itemeffectmeter.cpp
+++ b/src/game/client/tf/tf_hud_itemeffectmeter.cpp
@@ -298,6 +298,7 @@ void CHudItemEffectMeter::CreateHudElementsForClass( C_TFPlayer* pPlayer, CUtlVe
 	}
 	case TF_CLASS_DEMOMAN:
 		DECLARE_ITEM_EFFECT_METER( CTFSword, TF_WEAPON_SWORD, false, "resource/UI/HudItemEffectMeter_Demoman.res" );
+		lambdaAddItemEffectMeter("tf_weapon_stickbomb", true);
 		break;
 
 	case TF_CLASS_SOLDIER:

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -72,7 +72,7 @@ void DisableFloatingHealthCallback( IConVar *var, const char *oldString, float o
 ConVar tf_hud_target_id_disable_floating_health( "tf_hud_target_id_disable_floating_health", "0", FCVAR_ARCHIVE, "Set to disable floating health bar.  1 = everyone, 2 = normal players only.", DisableFloatingHealthCallback );
 ConVar tf_hud_target_id_alpha( "tf_hud_target_id_alpha", "100", FCVAR_ARCHIVE, "Alpha value of target id background, default 100" );
 ConVar tf_hud_target_id_offset( "tf_hud_target_id_offset", "0", FCVAR_ARCHIVE, "RES file Y offset for target id" );
-ConVar tf_hud_target_id_show_avatars( "tf_hud_target_id_show_avatars", "2", FCVAR_ARCHIVE, "Display Steam avatars on TargetID when using floating health icons.  1 = everyone, 2 = friends only." );
+ConVar tf_hud_target_id_show_avatars( "tf_hud_target_id_show_avatars", "1", FCVAR_ARCHIVE, "Display Steam avatars on TargetID when using floating health icons.  1 = everyone, 2 = friends only." );
 
 
 bool ShouldHealthBarBeVisible( CBaseEntity *pTarget, CTFPlayer *pLocalPlayer )

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -69,7 +69,7 @@ void DisableFloatingHealthCallback( IConVar *var, const char *oldString, float o
 		pTargetID->InvalidateLayout();
 	}
 }
-ConVar tf_hud_target_id_disable_floating_health( "tf_hud_target_id_disable_floating_health", "0", FCVAR_ARCHIVE, "Set to disable floating health bar", DisableFloatingHealthCallback );
+ConVar tf_hud_target_id_disable_floating_health( "tf_hud_target_id_disable_floating_health", "0", FCVAR_ARCHIVE, "Set to disable floating health bar.  1 = everyone, 2 = normal players only.", DisableFloatingHealthCallback );
 ConVar tf_hud_target_id_alpha( "tf_hud_target_id_alpha", "100", FCVAR_ARCHIVE, "Alpha value of target id background, default 100" );
 ConVar tf_hud_target_id_offset( "tf_hud_target_id_offset", "0", FCVAR_ARCHIVE, "RES file Y offset for target id" );
 ConVar tf_hud_target_id_show_avatars( "tf_hud_target_id_show_avatars", "2", FCVAR_ARCHIVE, "Display Steam avatars on TargetID when using floating health icons.  1 = everyone, 2 = friends only." );
@@ -82,7 +82,7 @@ bool ShouldHealthBarBeVisible( CBaseEntity *pTarget, CTFPlayer *pLocalPlayer )
 
 	// now second in priority to force floating health bars on for giant robots in MvM, robot destruction NPCs, and any custom game logic that forces the mini boss flag on players
 	// regardless of setting due to entities that return this check as true typically not having a visible target ID to fall back to when tf_hud_target_id_disable_floating_health is 1.
-	if ( pTarget->IsHealthBarVisible() )
+	if ( pTarget->IsHealthBarVisible() && tf_hud_target_id_disable_floating_health.GetInt() != 1 )
 		return true;
 
 	if ( tf_hud_target_id_disable_floating_health.GetBool() )
@@ -478,7 +478,7 @@ bool CTargetID::IsValidIDTarget( int nEntIndex, float flOldTargetRetainFOV, floa
 				//Recreate the floating health icon if there isn't one, we're not a spectator, and 
 				// we're not a spy or this was a robot from Robot Destruction-Mode
 				// force render floating health icon if it's a player miniboss or RD robot.
-				if ( !m_pFloatingHealthIcon && !bSpectator && ( !bSpy || bHealthBarVisible ) && ( !DrawHealthIcon() || pEnt->IsHealthBarVisible() ) )
+				if ( !m_pFloatingHealthIcon && !bSpectator && ( !bSpy || bHealthBarVisible ) && ( !DrawHealthIcon() || pEnt->IsHealthBarVisible() && tf_hud_target_id_disable_floating_health.GetInt() != 1 ) )
 				{
 					m_pFloatingHealthIcon = CFloatingHealthIcon::AddFloatingHealthIcon( pEnt );
 				}

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -44,6 +44,7 @@
 #include "tf_weapon_wrench.h"
 #include "tf_weapon_grenade_pipebomb.h"
 #include "tf_weapon_builder.h"
+#include "tf_objective_resource.h"
 
 #include "player_vs_environment/tf_population_manager.h"
 
@@ -3105,15 +3106,19 @@ void CBaseObject::UpgradeThink( void )
 //-----------------------------------------------------------------------------
 // Purpose: Handles health upgrade for objects we've already built
 //-----------------------------------------------------------------------------
-void CBaseObject::ApplyHealthUpgrade( void )
+void CBaseObject::ApplyHealthUpgrade(void)
 {
-	CTFPlayer *pTFPlayer = GetOwner();
-	if ( !pTFPlayer )
+	CTFPlayer* pTFPlayer = GetOwner();
+	if (!pTFPlayer)
 		return;
 
-	int iHealth = GetMaxHealthForCurrentLevel();
-	SetMaxHealth( iHealth );
-	SetHealth( iHealth );
+	int iMaxHealth = GetMaxHealthForCurrentLevel();
+	SetMaxHealth(iMaxHealth);
+	// set health up (or down) to max only between waves in MvM,
+	// or if current health would end up higher than max health (possible via "unbuying" the building health upgrade).
+	// fixes "infinite" building health exploit in both cases
+	if (TFObjectiveResource() && !TFObjectiveResource()->GetMannVsMachineIsBetweenWaves() || GetHealth() > iMaxHealth)
+		SetHealth(iMaxHealth);
 
 	//DevMsg( "%i\n", GetMaxHealth() );
 }

--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -738,11 +738,70 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 	if ( m_bStruckEnemy || (GetMoveType() == MOVETYPE_NONE) )
 		return;
 
-	if ( !pOther )
+	if (!pOther)
 		return;
 
-	bool bShield = pOther->IsCombatItem() && !InSameTeam( pOther );
-	CTFPumpkinBomb *pPumpkinBomb = dynamic_cast< CTFPumpkinBomb * >( pOther );
+	// Used when checking against things like FUNC_BRUSHES.
+	// Copied from CTFProjectile_EnergyRing::ProjectileTouch(), 
+	// but it's needed for penetrating arrows so this will only run when m_bPenetrate is true.
+	if (m_bPenetrate && !pOther->IsWorld() && pOther->GetSolid() == SOLID_VPHYSICS)
+	{
+		const trace_t* pTrace = &CBaseEntity::GetTouchTrace();
+		CPhysCollide* pTriggerCollide = modelinfo->GetVCollide(GetModelIndex())->solids[0];
+		Assert(pTriggerCollide);
+
+		CUtlVector<collidelist_t> collideList;
+		IPhysicsObject* pList[VPHYSICS_MAX_OBJECT_LIST_COUNT];
+		int physicsCount = pOther->VPhysicsGetObjectList(pList, ARRAYSIZE(pList));
+		vcollide_t* pVCollide = modelinfo->GetVCollide(pOther->GetModelIndex());
+
+		if (physicsCount)
+		{
+			for (int i = 0; i < physicsCount; i++)
+			{
+				const CPhysCollide* pCollide = pList[i]->GetCollide();
+				if (pCollide)
+				{
+					collidelist_t element;
+					element.pCollide = pCollide;
+					pList[i]->GetPosition(&element.origin, &element.angles);
+					collideList.AddToTail(element);
+				}
+			}
+		}
+		else if (pVCollide && pVCollide->solidCount)
+		{
+			collidelist_t element;
+			element.pCollide = pVCollide->solids[0];
+			element.origin = pOther->GetAbsOrigin();
+			element.angles = pOther->GetAbsAngles();
+			collideList.AddToTail(element);
+		}
+		else
+		{
+			return;
+		}
+
+		for (int i = collideList.Count() - 1; i >= 0; --i)
+		{
+			const collidelist_t& element = collideList[i];
+			trace_t tr;
+			physcollision->TraceCollide(pTrace->startpos, element.origin, element.pCollide, element.angles, pTriggerCollide, GetAbsOrigin(), GetAbsAngles(), &tr);
+			if (!tr.DidHit())
+				return;
+		}
+		if (!pOther->IsSolid() ||
+			pOther->IsSolidFlagSet(FSOLID_VOLUME_CONTENTS) ||
+			(pOther->GetCollisionGroup() == TFCOLLISION_GROUP_RESPAWNROOMS) ||
+			pOther->IsFuncLOD() ||
+			pOther->GetFlags() & FL_WORLDBRUSH)
+		{
+			return;
+		}
+	}
+
+	bool bShield = pOther->IsCombatItem() && !InSameTeam(pOther);
+	CTFPumpkinBomb* pPumpkinBomb = dynamic_cast<CTFPumpkinBomb*>(pOther);
 
 	if ( pOther->IsSolidFlagSet( FSOLID_TRIGGER | FSOLID_VOLUME_CONTENTS ) && !pPumpkinBomb && !bShield )
 		return;

--- a/src/game/server/tf/tf_projectile_flare.cpp
+++ b/src/game/server/tf/tf_projectile_flare.cpp
@@ -299,7 +299,7 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 	}
 
 	// If we've already got an impact time, don't impact again.
-	if ( m_flImpactTime > 0.0 )
+	if ( m_flImpactTime > 0.0  || (GetMoveType() == MOVETYPE_NONE) )
 		return;
 
 	// Save this entity as enemy, they will take 100% damage.
@@ -373,8 +373,24 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 		EmitSound( filter, pOther->entindex(), "TFPlayer.FlareImpact" );
 
 		SendDeathNotice();
-		UTIL_Remove( this );
+		FadeOut( 1.5 ); // fade out instead of removing immediately for the manmelter flare trail.
 	}
+}
+
+void CTFProjectile_Flare::FadeOut(int iTime)
+{
+	SetMoveType(MOVETYPE_NONE);
+	SetAbsVelocity(vec3_origin);
+	AddSolidFlags(FSOLID_NOT_SOLID);
+	AddEffects(EF_NODRAW);
+
+	// Start remove timer.
+	SetContextThink(&CTFProjectile_Flare::RemoveThink, gpGlobals->curtime + iTime, "FLARE_REMOVE_THINK");
+}
+
+void CTFProjectile_Flare::RemoveThink(void)
+{
+	UTIL_Remove( this );
 }
 
 //-----------------------------------------------------------------------------
@@ -428,7 +444,7 @@ void CTFProjectile_Flare::Explode_Air( trace_t *pTrace, int bitsDamageType, bool
 	CSoundEnt::InsertSound ( SOUND_COMBAT, vecOrigin, 1024, 3.0 );
 
 	SendDeathNotice();
-	UTIL_Remove( this );
+	FadeOut( 1.5 ); // fade out instead of removing immediately for the manmelter flare trail.
 }
 
 //-----------------------------------------------------------------------------
@@ -489,7 +505,7 @@ void CTFProjectile_Flare::ImpactThink( void )
 		}
 
 		SendDeathNotice();
-		UTIL_Remove( this );
+		FadeOut( 3.0 ); // fade out instead of removing immediately for the manmelter flare trail.
 		SetContextThink( NULL, 0, FLARE_THINK_CONTEXT );
 	}
 	else

--- a/src/game/server/tf/tf_projectile_flare.cpp
+++ b/src/game/server/tf/tf_projectile_flare.cpp
@@ -299,7 +299,7 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 	}
 
 	// If we've already got an impact time, don't impact again.
-	if ( m_flImpactTime > 0.0  || (GetMoveType() == MOVETYPE_NONE) )
+	if ( m_flImpactTime > 0.0 )
 		return;
 
 	// Save this entity as enemy, they will take 100% damage.
@@ -373,24 +373,8 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 		EmitSound( filter, pOther->entindex(), "TFPlayer.FlareImpact" );
 
 		SendDeathNotice();
-		FadeOut( 1.5 ); // fade out instead of removing immediately for the manmelter flare trail.
+		UTIL_Remove( this );
 	}
-}
-
-void CTFProjectile_Flare::FadeOut(int iTime)
-{
-	SetMoveType(MOVETYPE_NONE);
-	SetAbsVelocity(vec3_origin);
-	AddSolidFlags(FSOLID_NOT_SOLID);
-	AddEffects(EF_NODRAW);
-
-	// Start remove timer.
-	SetContextThink(&CTFProjectile_Flare::RemoveThink, gpGlobals->curtime + iTime, "FLARE_REMOVE_THINK");
-}
-
-void CTFProjectile_Flare::RemoveThink(void)
-{
-	UTIL_Remove( this );
 }
 
 //-----------------------------------------------------------------------------
@@ -444,7 +428,7 @@ void CTFProjectile_Flare::Explode_Air( trace_t *pTrace, int bitsDamageType, bool
 	CSoundEnt::InsertSound ( SOUND_COMBAT, vecOrigin, 1024, 3.0 );
 
 	SendDeathNotice();
-	FadeOut( 1.5 ); // fade out instead of removing immediately for the manmelter flare trail.
+	UTIL_Remove( this );
 }
 
 //-----------------------------------------------------------------------------
@@ -505,7 +489,7 @@ void CTFProjectile_Flare::ImpactThink( void )
 		}
 
 		SendDeathNotice();
-		FadeOut( 3.0 ); // fade out instead of removing immediately for the manmelter flare trail.
+		UTIL_Remove( this );
 		SetContextThink( NULL, 0, FLARE_THINK_CONTEXT );
 	}
 	else

--- a/src/game/server/tf/tf_projectile_flare.h
+++ b/src/game/server/tf/tf_projectile_flare.h
@@ -65,10 +65,7 @@ public:
 	void	SetCritical( bool bCritical ) { m_bCritical = bCritical; }
 	virtual int		GetDamageType();
 
-	void			FadeOut(int iTime);
-	void			RemoveThink();
-
-	virtual bool	IsDeflectable() OVERRIDE { return (GetMoveType() != MOVETYPE_NONE); }
+	virtual bool	IsDeflectable() { return true; }
 	virtual void	Deflected( CBaseEntity *pDeflectedBy, Vector &vecDir );
 	virtual bool	IsDestroyable( bool bOrbAttack = false ) OVERRIDE { return ( !bOrbAttack ? false : true ); }
 

--- a/src/game/server/tf/tf_projectile_flare.h
+++ b/src/game/server/tf/tf_projectile_flare.h
@@ -65,7 +65,10 @@ public:
 	void	SetCritical( bool bCritical ) { m_bCritical = bCritical; }
 	virtual int		GetDamageType();
 
-	virtual bool	IsDeflectable() { return true; }
+	void			FadeOut(int iTime);
+	void			RemoveThink();
+
+	virtual bool	IsDeflectable() OVERRIDE { return (GetMoveType() != MOVETYPE_NONE); }
 	virtual void	Deflected( CBaseEntity *pDeflectedBy, Vector &vecDir );
 	virtual bool	IsDestroyable( bool bOrbAttack = false ) OVERRIDE { return ( !bOrbAttack ? false : true ); }
 

--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -1581,7 +1581,7 @@ public:
 	virtual void RocketTouch( CBaseEntity *pOther ) OVERRIDE
 	{
 		Assert( pOther );
-		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() || pOther->GetFlags() & FL_WORLDBRUSH )
+		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() )
 			return;
 
 		if ( pOther->GetParent() == GetOwnerEntity() )
@@ -2812,7 +2812,7 @@ public:
 	virtual void RocketTouch( CBaseEntity *pOther ) OVERRIDE
 	{
 		Assert( pOther );
-		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() || pOther->GetFlags() & FL_WORLDBRUSH )
+		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() )
 			return;
 
 		const trace_t *pTrace = &CBaseEntity::GetTouchTrace();

--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -939,14 +939,14 @@ void CTFSpellBook::TossJarThink( void )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
+	float fRight = 7.f;
 	if ( IsViewModelFlipped() )
 	{
 		fRight *= -1;
 	}
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 	// Make spell toss position at the hand
-	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * 7.0f) + (vecForward * 3.0f);
+	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * fRight) + (vecForward * 3.0f);
 
 	Vector vecVelocity = GetVelocityVector( vecForward, vecRight, vecUp ) * pSpellData->m_flSpeedScale;
 	QAngle angForward = pPlayer->EyeAngles();
@@ -1417,6 +1417,7 @@ bool CTFSpellBook::CastRocketJump( CTFPlayer *pPlayer )
 	CTakeDamageInfo info;
 	info.SetAttacker( pPlayer );
 	info.SetInflictor( pPlayer ); 
+	info.SetWeapon( pPlayer->GetActiveWeapon() );
 	info.SetDamage( 20.f );
 	info.SetDamageCustom( TF_DMG_CUSTOM_SPELL_BLASTJUMP );
 	info.SetDamagePosition( origin );
@@ -1580,7 +1581,7 @@ public:
 	virtual void RocketTouch( CBaseEntity *pOther ) OVERRIDE
 	{
 		Assert( pOther );
-		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() )
+		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() || pOther->GetFlags() & FL_WORLDBRUSH )
 			return;
 
 		if ( pOther->GetParent() == GetOwnerEntity() )
@@ -1716,6 +1717,8 @@ public:
 		if ( pBaseTarget->GetTeamNumber() == GetTeamNumber() )
 			return;
 
+		CBaseEntity* pInflictor = GetLauncher();
+
 		if ( pTarget )
 		{
 			if ( pTarget->m_Shared.IsInvulnerable() )
@@ -1724,13 +1727,13 @@ public:
 			if ( pTarget->m_Shared.InCond( TF_COND_PHASE ) || pTarget->m_Shared.InCond( TF_COND_PASSTIME_INTERCEPTION ) )
 				return;
 
-			pTarget->m_Shared.SelfBurn( 5.0f );
+			// self burn from an enemy projectile just feels wrong. credit the damager properly
+			pTarget->m_Shared.Burn( pThrower, dynamic_cast<CTFWeaponBase*>( pInflictor ), 5.0f );
 		}
 
 		const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
 		trace_t *pNewTrace = const_cast<trace_t*>( pTrace );
 
-		CBaseEntity *pInflictor = GetLauncher();
 		CTakeDamageInfo info;
 		info.SetAttacker( pThrower );
 		info.SetInflictor( this ); 
@@ -2809,7 +2812,7 @@ public:
 	virtual void RocketTouch( CBaseEntity *pOther ) OVERRIDE
 	{
 		Assert( pOther );
-		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() )
+		if ( !pOther || !pOther->IsSolid() || pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) || pOther->IsFuncLOD() || pOther->GetFlags() & FL_WORLDBRUSH )
 			return;
 
 		const trace_t *pTrace = &CBaseEntity::GetTouchTrace();

--- a/src/game/shared/tf/tf_dropped_weapon.cpp
+++ b/src/game/shared/tf/tf_dropped_weapon.cpp
@@ -572,19 +572,21 @@ void CTFDroppedWeapon::InitDroppedWeapon( CTFPlayer *pPlayer, CTFWeaponBase *pWe
 		}
 	}
 
-	if ( bIsSuicide )
+
+	CWeaponMedigun* pMedigun = dynamic_cast<CWeaponMedigun*>(pWeapon);
+	if (pMedigun)
 	{
-		m_flChargeLevel = 0.f;
-	}
-	else
-	{
-		CWeaponMedigun *pMedigun = dynamic_cast< CWeaponMedigun* >( pWeapon );
-		if ( pMedigun )
+		SetBodygroup(1, 1); // previously from when weapons were ammo boxes- removes medigun hose
+		if (bIsSuicide)
 		{
-			m_flChargeLevel.Set( pMedigun->GetChargeLevel() );
-			if ( m_flChargeLevel > 0.f )
+			m_flChargeLevel = 0.f;
+		}
+		else
+		{
+			m_flChargeLevel.Set(pMedigun->GetChargeLevel());
+			if (m_flChargeLevel > 0.f)
 			{
-				SetContextThink( &CTFDroppedWeapon::ChargeLevelDegradeThink, gpGlobals->curtime + 0.1f, "ChargeLevelDegradeThink" );
+				SetContextThink(&CTFDroppedWeapon::ChargeLevelDegradeThink, gpGlobals->curtime + 0.1f, "ChargeLevelDegradeThink");
 			}
 		}
 	}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6533,6 +6533,10 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		int iForceCritDmgFalloff = 0;
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iForceCritDmgFalloff, crit_dmg_falloff );
 
+		// Move this higher to fix the lack of minicrit rampup damage upon being crit boosted.
+		int iDemoteCritToMinicrit = 0;
+		CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iDemoteCritToMinicrit, crits_become_minicrits );
+
 #ifdef MCOMS_BALANCE_PACK
 		// SMG headshots falloff
 		if ( pWeapon && pWeapon->GetWeaponID() == TF_WEAPON_SMG )
@@ -6552,7 +6556,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 								 ( ( bCrit && tf_weapon_criticals_distance_falloff.GetBool() ) || 
 								 ( info.GetCritType() == CTakeDamageInfo::CRIT_MINI && tf_weapon_minicrits_distance_falloff.GetBool() ) || 
 								 ( iForceCritDmgFalloff ) );
-		bool bDoShortRangeDistanceIncrease = !bCrit || info.GetCritType() == CTakeDamageInfo::CRIT_MINI ;
+		bool bDoShortRangeDistanceIncrease = !bCrit || iDemoteCritToMinicrit != 0 || info.GetCritType() == CTakeDamageInfo::CRIT_MINI ;
 		bool bDoLongRangeDistanceDecrease = !bIgnoreLongRangeDmgEffects && ( bForceCritFalloff || ( !bCrit && info.GetCritType() != CTakeDamageInfo::CRIT_MINI  ) );
 
 		// If we're doing any distance modification, we need to do that first
@@ -6782,8 +6786,6 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		}
 		else if ( bCrit )
 		{
-			int iDemoteCritToMinicrit = 0;
-			CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iDemoteCritToMinicrit, crits_become_minicrits );
 			if ( iDemoteCritToMinicrit != 0 )
 			{
 				bitsDamage &= ~DMG_CRITICAL; // this is to shutup the assert in lambdaDoMinicrit

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5679,7 +5679,8 @@ void CTFGameRules::RadiusDamage( CTFRadiusDamageInfo &info )
 //-----------------------------------------------------------------------------
 void CTFRadiusDamageInfo::CalculateFalloff( void )
 {
-	if ( dmgInfo->GetDamageType() & DMG_RADIUS_MAX )
+	// hack to ignore caber explosion, otherwise the charge minicrit explosion would actually do less damage
+	if (dmgInfo->GetDamageCustom() != TF_DMG_CUSTOM_STICKBOMB_EXPLOSION && dmgInfo->GetDamageType() & DMG_RADIUS_MAX)
 		flFalloff = 0.f;
 	else if ( dmgInfo->GetDamageType() & DMG_HALF_FALLOFF )
 		flFalloff = 0.5f;

--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -812,6 +812,34 @@ ShadowType_t CTFWearableVM::ShadowCastType( void )
 
 	return SHADOWS_RENDER_TO_TEXTURE;
 }
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//		Allow botkiller attachments and server mod viewmodel VMs to properly flip with the player's weapon.
+//-----------------------------------------------------------------------------
+int CTFWearableVM::InternalDrawModel(int flags)
+{
+	C_TFPlayer* pOwner = ToTFPlayer(GetOwnerEntity());
+
+	CMatRenderContextPtr pRenderContext(materials);
+
+	if (pOwner)
+	{
+		CTFWeaponBase* pWpn = pOwner->GetActiveTFWeapon();
+
+		if (pWpn)
+		{
+			if (pWpn->IsViewModelFlipped())
+				pRenderContext->CullMode(MATERIAL_CULLMODE_CW);
+		}
+	}
+
+	int ret = BaseClass::InternalDrawModel(flags);
+
+	pRenderContext->CullMode(MATERIAL_CULLMODE_CCW);
+
+	return ret;
+}
 #endif
 
 

--- a/src/game/shared/tf/tf_item_wearable.h
+++ b/src/game/shared/tf/tf_item_wearable.h
@@ -109,6 +109,8 @@ public:
 
 #if defined( CLIENT_DLL )
 	virtual ShadowType_t ShadowCastType( void );
+
+	virtual int			InternalDrawModel(int flags);
 #endif
 };
 

--- a/src/game/shared/tf/tf_projectile_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_projectile_dragons_fury.cpp
@@ -181,6 +181,7 @@ public:
 			 pOther->IsSolidFlagSet( FSOLID_NOT_SOLID ) ||
 			 ( pOther->GetCollisionGroup() == TFCOLLISION_GROUP_RESPAWNROOMS ) ||
 			 pOther->IsFuncLOD() ||
+			pOther->GetFlags() & FL_WORLDBRUSH || // hack for func_brushes
 			 pOther->IsBaseProjectile() )
 		{
 			return;

--- a/src/game/shared/tf/tf_projectile_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_projectile_dragons_fury.cpp
@@ -181,7 +181,7 @@ public:
 			 pOther->IsSolidFlagSet( FSOLID_NOT_SOLID ) ||
 			 ( pOther->GetCollisionGroup() == TFCOLLISION_GROUP_RESPAWNROOMS ) ||
 			 pOther->IsFuncLOD() ||
-			pOther->GetFlags() & FL_WORLDBRUSH || // hack for func_brushes
+//			pOther->GetFlags() & FL_WORLDBRUSH && !pOther->IsWorld() || // hack for func_brushes
 			 pOther->IsBaseProjectile() )
 		{
 			return;

--- a/src/game/shared/tf/tf_projectile_energy_ring.cpp
+++ b/src/game/shared/tf/tf_projectile_energy_ring.cpp
@@ -222,7 +222,8 @@ void CTFProjectile_EnergyRing::ProjectileTouch( CBaseEntity *pOther )
 		 !pOther->IsSolid() ||
 		 pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS ) ||
 		 ( pOther->GetCollisionGroup() == TFCOLLISION_GROUP_RESPAWNROOMS ) ||
-		 pOther->IsFuncLOD() )
+		 pOther->IsFuncLOD() ||
+		pOther->GetFlags() & FL_WORLDBRUSH) // Hack for func_brushes
 	{
 		return;
 	}
@@ -257,7 +258,8 @@ void CTFProjectile_EnergyRing::ProjectileTouch( CBaseEntity *pOther )
 	if ( bCombatEntity )
 	{
 		// Bison projectiles shouldn't collide with friendly things
-		if ( ShouldPenetrate() && ( pOther->InSameTeam( this ) || ( gpGlobals->curtime - m_flLastHitTime ) < tf_bison_tick_time.GetFloat() ) )
+		// Pomson projectiles shouldn't collide with nearby teammates
+		if ( ( ShouldPenetrate() || !CanCollideWithTeammates() ) && ( pOther->InSameTeam( this ) || ( gpGlobals->curtime - m_flLastHitTime ) < tf_bison_tick_time.GetFloat() ) )
 			return;
 
 		m_flLastHitTime = gpGlobals->curtime;

--- a/src/game/shared/tf/tf_projectile_nail.cpp
+++ b/src/game/shared/tf/tf_projectile_nail.cpp
@@ -55,6 +55,13 @@ CTFBaseProjectile *CTFProjectile_Syringe::Create(
 	CBaseEntity *pScorer /*= NULL*/, 
 	bool bCritical /*= false */
 ) {
+	float flVelocity = SYRINGE_VELOCITY;
+	if (pLauncher) // customizable syringe spread and range for server mods.
+	{
+		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(pLauncher, flVelocity, mult_projectile_speed);
+		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(pLauncher, flVelocity, mult_projectile_range);
+	}
+
 	return CTFBaseProjectile::Create( "tf_projectile_syringe", vecOrigin, vecAngles, pOwner, SYRINGE_VELOCITY, g_sModelIndexSyringe, SYRINGE_DISPATCH_EFFECT, pScorer, bCritical );
 }
 

--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -660,8 +660,6 @@ const char *CTFStunBall::GetBallViewModelName( void ) const
 //-----------------------------------------------------------------------------
 void CTFStunBall::Spawn( void )
 {
-	SetDetonateTimerLength(FLT_MAX); // makes the ball never fizzle out mid-air
-
 	BaseClass::Spawn();
 
 	SetModel( GetBallModelName() );

--- a/src/game/shared/tf/tf_weapon_bat.h
+++ b/src/game/shared/tf/tf_weapon_bat.h
@@ -150,6 +150,7 @@ public:
 
 	virtual bool		IsAllowedToExplode( void ) OVERRIDE { return false; }
 	virtual void		Explode( trace_t *pTrace, int bitsDamageType );
+	virtual void		DetonateThink() OVERRIDE;
 	virtual void		ApplyBallImpactEffectOnVictim( CBaseEntity *pOther );
 	virtual void		PipebombTouch( CBaseEntity *pOther );
 	virtual void		VPhysicsCollision( int index, gamevcollisionevent_t *pEvent );
@@ -178,6 +179,7 @@ private:
 #else
 	virtual const char *GetTrailParticleName( void );
 	virtual void	CreateTrailParticles( void );
+	virtual void		OnDataChanged(DataUpdateType_t updateType);
 
 #endif
 
@@ -235,6 +237,11 @@ public:
 	void				VPhysicsCollisionThink( void );
 
 	virtual void		ApplyBallImpactEffectOnVictim( CBaseEntity *pOther );
+
+	void			FadeOut(int iTime);
+	void			RemoveThink();
+
+	virtual bool	IsDeflectable() OVERRIDE { return (GetMoveType() != MOVETYPE_NONE); }
 
 protected:
 		Vector		m_vCollisionVelocity;

--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -225,6 +225,11 @@ void CTFStickBomb::Smack( void )
 	{
 		m_iDetonated = 1;
 		m_bBroken = true;
+		CTFPlayer* pOwner = GetTFPlayerOwner();
+		if (pOwner)
+		{
+			pOwner->m_Shared.SetItemChargeMeter(LOADOUT_POSITION_MELEE, 0.f);
+		}
 		SwitchBodyGroups();
 
 #ifdef GAME_DLL
@@ -347,3 +352,12 @@ void RecvProxy_Detonated( const CRecvProxyData *pData, void *pStruct, void *pOut
 }
 
 #endif
+
+void CTFStickBomb::OnResourceMeterFilled()
+{
+	CTFPlayer* pOwner = GetTFPlayerOwner();
+	if (!pOwner)
+		return;
+
+	WeaponRegenerate();
+}

--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -256,6 +256,8 @@ void CTFStickBomb::Smack( void )
 			int dmgType = DMG_BLAST | DMG_NOCLOSEDISTANCEMOD;
 			if ( IsCurrentAttackACrit() )
 				dmgType |= DMG_CRITICAL;
+			else if (m_bMiniCrit) // the explosion minicrits from the charge minicrit, too
+				dmgType |= DMG_RADIUS_MAX;
 
 			CTakeDamageInfo info( pTFPlayer, pTFPlayer, this, explosion, explosion, 75.0f, dmgType, TF_DMG_CUSTOM_STICKBOMB_EXPLOSION, &explosion );
 			CTFRadiusDamageInfo radiusinfo( &info, explosion, 100.f );

--- a/src/game/shared/tf/tf_weapon_bottle.h
+++ b/src/game/shared/tf/tf_weapon_bottle.h
@@ -102,6 +102,7 @@ public:
 
 	void				SetDetonated( int iVal ) { m_iDetonated = iVal; }
 	int					GetDetonated( void ) { return m_iDetonated; }
+	virtual void		OnResourceMeterFilled() OVERRIDE;
 
 private:
 

--- a/src/game/shared/tf/tf_weapon_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.cpp
@@ -109,6 +109,8 @@ void CTFWeaponFlameBall::PrimaryAttack( void )
 #else
 	C_CTF_GameStats.Event_PlayerFiredWeapon( pPlayer, IsCurrentAttackACrit() );
 #endif
+	// the DF does not list a "no random crits" stat, therefore it should random crit
+	CalcIsAttackCritical();
 
 	SendWeaponAnim( ACT_VM_PRIMARYATTACK );
 
@@ -147,14 +149,14 @@ CBaseEntity* CTFWeaponFlameBall::FireProjectile( CTFPlayer *pPlayer )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
+	float fRight = 7.f;
 	if ( IsViewModelFlipped() )
 	{
 		fRight *= -1;
 	}
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 	// Shoot from the right location
-	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * 7.0f) + (vecForward * 3.0f);
+	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * fRight) + (vecForward * 3.0f);
 
 	QAngle angForward = pPlayer->EyeAngles();
 
@@ -180,7 +182,7 @@ CBaseEntity* CTFWeaponFlameBall::FireProjectile( CTFPlayer *pPlayer )
 
 		pRocket->SetDamage( 20 );
 		pRocket->ChangeTeam( pPlayer->GetTeamNumber() );
-		pRocket->SetCritical( pPlayer->m_Shared.IsCritBoosted() );
+		pRocket->SetCritical( IsCurrentAttackACrit() );
 
 		DispatchSpawn( pRocket );
 

--- a/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
+++ b/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
@@ -781,6 +781,7 @@ void CTFGrenadePipebombProjectile::PipebombTouch( CBaseEntity *pOther )
 					// Impact damage scales with distance
 					float flDistanceSq = (pOther->GetAbsOrigin() - pAttacker->GetAbsOrigin()).LengthSqr();
 					float flImpactDamage = RemapValClamped( flDistanceSq, 512 * 512, 1024 * 1024, 50, 25 );
+					CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(GetLauncher(), flImpactDamage, mult_dmg);
 
 					CTakeDamageInfo info( this, pAttacker, GetOriginalLauncher(), vec3_origin, vOrigin, flImpactDamage, GetDamageType(), TF_DMG_CUSTOM_CANNONBALL_PUSH );
 					pOther->TakeDamage( info );

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -542,7 +542,9 @@ void CTFProjectile_Jar::PipebombTouch( CBaseEntity *pOther )
 		// Exception to this rule - if we're a jar or milk, and our potential victim is on fire, then allow collision after all.
 		// If we're a jar or milk, then still allow collision if our potential victim is on fire.
 		// This condition only applies to non-cleaver jars, since there's so many jar types capable of extinguishing.
-		if ( m_iProjectileType != TF_PROJECTILE_CLEAVER )
+		if ( m_iProjectileType != TF_PROJECTILE_CLEAVER && 
+			m_iProjectileType != TF_PROJECTILE_SPELL && 
+			m_iProjectileType != TF_PROJECTILE_THROWABLE)
 		{
 			auto victim = ToTFPlayer(pOther);
 			if (!victim->m_Shared.InCond(TF_COND_BURNING))

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -11,8 +11,10 @@
 // Client specific.
 #ifdef CLIENT_DLL
 #include "c_tf_player.h"
+#include "c_basedoor.h"
 // Server specific.
 #else
+#include "doors.h"
 #include "soundent.h"
 #include "te_effect_dispatch.h"
 #include "tf_player.h"
@@ -539,7 +541,8 @@ void CTFProjectile_Jar::PipebombTouch( CBaseEntity *pOther )
 	{
 		// Exception to this rule - if we're a jar or milk, and our potential victim is on fire, then allow collision after all.
 		// If we're a jar or milk, then still allow collision if our potential victim is on fire.
-		if (m_iProjectileType == TF_PROJECTILE_JAR || m_iProjectileType == TF_PROJECTILE_JAR_MILK)
+		// This condition only applies to non-cleaver jars, since there's so many jar types capable of extinguishing.
+		if ( m_iProjectileType != TF_PROJECTILE_CLEAVER )
 		{
 			auto victim = ToTFPlayer(pOther);
 			if (!victim->m_Shared.InCond(TF_COND_BURNING))
@@ -943,7 +946,39 @@ CTFProjectile_Jar *CTFCleaver::CreateJarProjectile( const Vector &position, cons
 {
 	return CTFProjectile_Cleaver::Create( position, angles, velocity, angVelocity, pOwner, weaponInfo, GetSkin() );
 }
+
 #endif
+
+//-----------------------------------------------------------------------------
+// Purpose: Determines if there is space to create a cleaver. 
+//			The player technically has a 0.1s window between this passing through and then aiming against the wall
+//			to get the cleaver through the it, but this is difficult to do so this bug has been effectively mitigated.
+//-----------------------------------------------------------------------------
+bool CTFCleaver::CanCreateCleaver(CTFPlayer* pPlayer)
+{
+	Vector vecForward, vecUp;
+	AngleVectors(pPlayer->EyeAngles(), &vecForward, NULL, &vecUp);
+	Vector vecCleaverStart = pPlayer->GetAbsOrigin() + Vector(0, 0, 50);
+	Vector vecCleaverlEnd = vecCleaverStart + vecForward * 32.f;
+
+	// Trace out and see if we hit a wall.
+	trace_t trace;
+	CTraceFilterSimple traceFilter(this, COLLISION_GROUP_NONE);
+	UTIL_TraceHull(vecCleaverStart, vecCleaverlEnd, -Vector(8, 8, 8), Vector(8, 8, 8), MASK_SOLID_BRUSHONLY, &traceFilter, &trace);
+	if (trace.DidHitWorld() || trace.startsolid)
+		return false;
+	else
+	{
+		if (trace.m_pEnt)
+		{
+			// Don't let the player throw the cleaver through doors.
+			CBaseDoor* pDoor = dynamic_cast<CBaseDoor*>(trace.m_pEnt);
+			if (pDoor)
+				return false;
+		}
+		return true;
+	}
+}
 
 //-----------------------------------------------------------------------------
 // Purpose:
@@ -953,6 +988,23 @@ float CTFCleaver::GetProjectileSpeed( void )
 	return TF_CLEAVER_LAUNCH_SPEED;
 }
 
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+void CTFCleaver::PrimaryAttack(void)
+{
+	CTFPlayer* pPlayer = GetTFPlayerOwner();
+	if (!pPlayer)
+		return;
+
+	if ( CanCreateCleaver(pPlayer) )
+		return BaseClass::PrimaryAttack();
+
+	return;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
 //-----------------------------------------------------------------------------
 void CTFCleaver::SecondaryAttack( void )
 {
@@ -1129,6 +1181,14 @@ void CTFProjectile_Cleaver::Detonate( void )
 	UTIL_TraceLine ( vecSpot, vecSpot + Vector ( 0, 0, -32 ), MASK_SHOT_HULL, this, COLLISION_GROUP_NONE, & tr);
 
 	Explode( &tr, GetDamageType() );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFProjectile_Cleaver::DetonateThink(void)
+{
+	// nothing here, so the cleaver never fizzles out
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weapon_jar.h
+++ b/src/game/shared/tf/tf_weapon_jar.h
@@ -114,11 +114,14 @@ public:
 	virtual int			GetWeaponID( void ) const			{ return TF_WEAPON_CLEAVER; }
 	virtual float		GetProjectileSpeed( void );
 
+	virtual void		PrimaryAttack(void);
 	virtual void		SecondaryAttack( void );
 
 	virtual const char*			GetEffectLabelText( void ) { return "#TF_CLEAVER"; }
 
 	virtual float		InternalGetEffectBarRechargeTime( void ) { return 5.1; }
+
+	virtual bool		CanCreateCleaver(CTFPlayer* pPlayer);
 
 #ifdef GAME_DLL
 	virtual const AngularImpulse GetAngularImpulse( void ){ return AngularImpulse( 0, 500, 0 ); }
@@ -244,6 +247,7 @@ public:
 	virtual void		OnHit( CBaseEntity *pOther ) OVERRIDE;
 	virtual void		Explode( trace_t *pTrace, int bitsDamageType ) OVERRIDE;
 	virtual void		Detonate() OVERRIDE;
+	virtual void		DetonateThink() OVERRIDE;
 	virtual const char* GetImpactEffect() OVERRIDE { return ""; }
 	virtual ETFCond		GetEffectCondition( void ) OVERRIDE { return TF_COND_BLEEDING; }
 	

--- a/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
+++ b/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
@@ -647,6 +647,9 @@ bool CTFProjectile_MechanicalArmOrb::ShouldProjectileIgnore( CBaseEntity *pOther
 	if ( pOther->IsFuncLOD() )
 		return true;
 
+	if ( pOther->GetFlags() & FL_WORLDBRUSH )
+		return true;
+
 	const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
 	if ( pTrace->surface.flags & CONTENTS_LADDER )
 		return true;

--- a/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
+++ b/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
@@ -250,12 +250,13 @@ void CTFMechanicalArm::SecondaryAttack( void )
 
 	if ( ShockAttack() )
 	{
+		CalcIsAttackCritical();
 		WeaponSound( SPECIAL3 );
 #ifdef GAME_DLL
 		Vector vecForward, vecRight, vecUp;
 		AngleVectors( pOwner->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-		float fRight = 8.f;
+		float fRight = 15.f;
 		if ( IsViewModelFlipped() )
 		{
 			fRight *= -1;
@@ -264,7 +265,7 @@ void CTFMechanicalArm::SecondaryAttack( void )
 // 		vecSrc = vecSrc + ( vecUp * -9.0f ) + ( vecRight * 7.0f ) + ( vecForward * 3.0f );
 		Vector vecSrc = pOwner->EyePosition()
 			+ ( vecForward * 40.f )
-			+ ( vecRight * 15.f )
+			+ ( vecRight * fRight )
 			+ ( vecUp * -10.f );
 
 		QAngle angForward = pOwner->EyeAngles();
@@ -287,7 +288,8 @@ void CTFMechanicalArm::SecondaryAttack( void )
 				pOrb->SetAbsVelocity( vForward * tf_mecharm_orb_speed );
 
 				pOrb->ChangeTeam( pOwner->GetTeamNumber() );
-				pOrb->SetCritical( false );
+				pOrb->SetCritical( IsCurrentAttackACrit() );
+//				pOrb->SetCritical( false );
 
 				DispatchSpawn( pOrb );
 			}
@@ -478,6 +480,8 @@ void CTFMechanicalArm::PrimaryAttack()
 	
 	//int nAmmoToTake = bShocked ? 0 : GetAmmoPerShot();
 	//pOwner->RemoveAmmo( nAmmoToTake, m_iPrimaryAmmoType );
+
+	CalcIsAttackCritical(); // fix for weapon being incapable of dealing critical hits with primary fire
 
 	FireProjectile( pPlayer );
 #endif
@@ -745,7 +749,14 @@ void CTFProjectile_MechanicalArmOrb::CheckForPlayers( int nNumToZap, bool bCanHi
 	info.SetDamage( tf_mecharm_orb_zap_damage );
 	info.SetDamageCustom( TF_DMG_CUSTOM_PLASMA );
 	info.SetDamagePosition( GetAbsOrigin() );
-	info.SetDamageType( DMG_SHOCK );
+
+	// the short circuit already can't random crit, so this is in place for when the owner is crit boosted via external means.
+	int iDmgType = DMG_SHOCK;
+	if ( IsCritical() )
+	{
+		iDmgType |= DMG_CRITICAL;
+	}
+	info.SetDamageType( iDmgType );
 
 	CBaseEntity *pListOfEntities[5];
 	int iEntities = UTIL_EntitiesInSphere( pListOfEntities, 5, GetAbsOrigin(), tf_mecharm_orb_size, FL_CLIENT | FL_FAKECLIENT | FL_NPC );

--- a/src/game/shared/tf/tf_weapon_throwable.cpp
+++ b/src/game/shared/tf/tf_weapon_throwable.cpp
@@ -313,7 +313,7 @@ CTFProjectile_Throwable *CTFThrowable::FireProjectileInternal( void )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
+	float fRight = 7.f;
 	if ( IsViewModelFlipped() )
 	{
 		fRight *= -1;
@@ -321,7 +321,7 @@ CTFProjectile_Throwable *CTFThrowable::FireProjectileInternal( void )
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 
 	// Make spell toss position at the hand
-	vecSrc = vecSrc + ( vecUp * -9.0f ) + ( vecRight * 7.0f ) + ( vecForward * 3.0f );
+	vecSrc = vecSrc + ( vecUp * -9.0f ) + ( vecRight * fRight ) + ( vecForward * 3.0f );
 
 	trace_t trace;
 	Vector vecEye = pPlayer->EyePosition();

--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -636,6 +636,7 @@ CBaseEntity *CTFWeaponBaseGun::FireNail( CTFPlayer *pPlayer, int iSpecificNail )
 	// Add some spread
 	float flSpread = 1.5;
 	flSpread += GetProjectileSpread();
+	CALL_ATTRIB_HOOK_FLOAT(flSpread, mult_spread_scale); // accuracy multiplier support for server mods
 
 	CTFBaseProjectile *pProjectile = NULL;
 	switch( iSpecificNail )


### PR DESCRIPTION
### Related Issue
<!-- Number of the issue where this topic was mentioned -->
- No issue has been made in conjunction with this.

### Implementation
<!-- A clear and concise description of what the changes are -->
This is just a large pool of weapon changes I've made to improve consistency with weapons that have had (quite frankly) better programming put behind them, fix existing bugs and exploits, and introduce better attribute support for various things.

 - **Setting tf_hud_target_id_disable_floating_health to 2 now shows giant robot and RD robot health above their heads instead of not displaying health at all**

 - **Improved support for the "Allows you to see enemy health" attribute, now properly displaying enemy names on all classes.**

 - **Enemy target IDs are now labeled differently, using the previously underutilized "#TF_playerid_diffteam" localization string**
_(Enemy disguised spies are still labeled as if they're on your team)_

 - **Fixed flipped viewmodels inversing the material cullmodes for Sandman baseballs, Wrap Assassin baubles, and botkiller heads in first person.**

 - **Dropped Medi Guns now have their back hose removed again, like how it was pre-Gun Mettle**

 - **The Ullapool Caber can now deal minicrit explosion damage via charging**

 - **Fixed an exploit regarding the building health upgrade in MvM allowing for infinite, instant full health refills**

 - **The Loose Cannon's cannonball impact damage now scales with damage upgrades in MvM**

 - **Pomson 6000 and Wrap Assassin projectiles can now pass through teammates at close range, now being more consistent with other projectiles.**

 - **Wrap Assassin baubles now no longer have their trails poof out of thin air once it hits something and explodes**

 - **Fixed Wrap Assassin baubles exploding twice on player impact**
_(The explosion damage multiplier has been bumped up from 0.9 to 1.8 to compensate.)_

 - **Critical Wrap Assassin baubles can now deal crit explosion damage**

 - **Sandman baseballs, Wrap Assassin baubles and Flying Guillotine cleavers no longer "detonate" in midair, remaining active until it eventually hits something**

 - **The Flying Guillotine now has a close-range wall check 1:1 with the Sandman and Wrap Assassin before being able to be thrown**
_(This mitigates the cleaver through walls bug)_

 - **Dragon's Fury and Short Circuit (primary and secondary fire) are now capable of scoring critical hits.**
_(The Short Circuit cannot random crit, so this only benefits the Engineer if he's critboosted via external means.)_

 - **Spellbook Fireballs now credit the afterburn damage to the attacker rather than it being regarded as self-damage**
_(TODO: Make afterburn kills from this use the fireball killicon.)_

 - **Syringe projectiles can now be affected by both projectile speed (mult_projectile_speed) and spread (mult_spread_scale) attributes**

 - **Fixed Festive Jarate, Self-Aware Beauty Mark, and Mutated Milk projectiles failing to intentionally collide with burning teammates at point-blank**

 - **Added support for a rechargeable Ullapool Caber. This behavior is disabled by default, acting like live TF2's non-rechargeable Caber unless the required static attribs (item_meter_charge_type, item_meter_charge_rate, etc.) have been defined.**
 
 - **Fixed the Cow Mangler 5000 not having damage rampup with it's minicrit damage while crit boosted**

 - **The following projectiles have been fixed to now ignore func_brushes:**
Arrows with projectile penetration upgrade
Righteous Bison/Pomson 6000 projectiles
Wrap Assassin bauble
_(Wrap Assassin bounces off of real collision from func_brushes, but that's okay. I was unable to cleanly implement collision fixes for the Dragon's Fury and Short Circuit, though. These could be better implemented by someone else in the future.)_

 - **The following projectiles have been fixed to now respect flipped viewmodels, spawning on the left when applicable:**
Dragon's Fury's fireball
Short Circuit's energy orb
All spellbook projectiles
Unused "throwable" projectiles

### Screenshots
<!-- Add screenshots if applicable -->
![image](https://github.com/user-attachments/assets/8e5c9d6b-429d-40e8-a5f0-bfdba527ac51)
![image](https://github.com/user-attachments/assets/fb146550-1ce6-4ace-94d3-607943ca5fee)
![image](https://github.com/user-attachments/assets/f1df4c54-47b0-4fbe-b2cb-476116970340)
![image](https://github.com/user-attachments/assets/eee66409-6a9e-4b94-a861-6ca51bff5e1b)
![image](https://github.com/user-attachments/assets/1631c330-c84a-478a-a10c-1926e98a65dc)
![image](https://github.com/user-attachments/assets/dd6a316f-154f-45ee-8d0a-d1f682657ca5)
![image](https://github.com/user-attachments/assets/50308129-793d-40cb-8cdb-eb8060856d24)
![image](https://github.com/user-attachments/assets/f57e5bf7-15bd-4e5b-b41c-8b1f9fff3f51)
![image](https://github.com/user-attachments/assets/ffeaab45-487a-4bed-b80a-425be2b77912)
![image](https://github.com/user-attachments/assets/64a95d41-4e12-4d2a-aa89-570c90047574)
![image](https://github.com/user-attachments/assets/5ae4f058-914f-4484-b10b-55d7a1c2dea4)
![image](https://github.com/user-attachments/assets/c026df50-5b84-4cb6-b497-2eb759c43ee8)
![image](https://github.com/user-attachments/assets/a280fa38-9b3c-46ab-8458-8d5e410a4e3a)
![image](https://github.com/user-attachments/assets/b529d24a-18b1-47d7-896b-4e74661a5aa6)


### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [ ] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | Tested | Windows 11 |
|   Linux | N/A | N/A |     N/A |

### Caveats
<!-- Any caveats and side effects of this PR -->
Wrap Assassin baubles now bounce off of real collisions with func_brushes. This is behavior already present in live TF2 with func_doors, however. This could be better implemented by someone else in the future.
Spellbook Fireball afterburn kills now need to have their killicon upadted to not use the generic flamethrower killicon

### Alternatives
<!-- Alternatives that were considered -->
I had thought about not boosting the Wrap Assassin's splash damage for the double explosion bugfix, but it would ultimately nerf the weapon's damage output by 4-13 on a direct impact from doing so. This can be decided by Valve, should this get implemented.