### PR TITLE
Inspect issues fix

### DIFF
--- a/src/game/shared/tf/tf_weapon_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.cpp
@@ -245,6 +245,11 @@ bool CTFWeaponFlameBall::HasFullCharge() const
 	return pOwner->m_Shared.GetItemChargeMeter( LOADOUT_POSITION_PRIMARY) >= 100.f;
 }
 
+bool CTFWeaponFlameBall::CanInspect() const
+{
+    return BaseClass::CanInspect() && HasFullCharge();
+}
+
 void CTFWeaponFlameBall::ItemPostFrame( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );

--- a/src/game/shared/tf/tf_weapon_dragons_fury.h
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.h
@@ -55,6 +55,8 @@ public:
 	virtual void	OnResourceMeterFilled() OVERRIDE;
 	virtual float	GetMeterMultiplier() const OVERRIDE;
 
+	virtual bool	CanInspect() const OVERRIDE;
+
 #ifdef GAME_DLL
 	virtual float GetInitialAfterburnDuration() const OVERRIDE { return 0.f; }
 	void RefundAmmo( int nAmmo );

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -510,6 +510,14 @@ void CTFFlameThrower::UpdateOnRemove( void )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+bool CTFFlameThrower::CanInspect() const
+{
+    return BaseClass::CanInspect() && !IsFiring();
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 bool CTFFlameThrower::Holster( CBaseCombatWeapon *pSwitchingTo )

--- a/src/game/shared/tf/tf_weapon_flamethrower.h
+++ b/src/game/shared/tf/tf_weapon_flamethrower.h
@@ -111,6 +111,7 @@ public:
 	bool			EffectMeterShouldFlash( void );
 
 	virtual bool	Deploy( void ) OVERRIDE;
+	virtual bool	CanInspect() const OVERRIDE;
 
 #if defined( CLIENT_DLL )
 

--- a/src/game/shared/tf/tf_weapon_grenadelauncher.cpp
+++ b/src/game/shared/tf/tf_weapon_grenadelauncher.cpp
@@ -545,6 +545,16 @@ float CTFGrenadeLauncher::GetChargeMaxTime( void )
 	return GetMortarDetonateTimeLength();
 }
 
+bool CTFGrenadeLauncher::CanInspect() const
+{
+    // we are charging a ball, so don't inspect
+    if ( m_flDetonateTime > gpGlobals->curtime )
+    {
+        return false;
+    }
+
+    return BaseClass::CanInspect();
+}
 
 void CTFGrenadeLauncher::ResetDetonateTime()
 {

--- a/src/game/shared/tf/tf_weapon_grenadelauncher.h
+++ b/src/game/shared/tf/tf_weapon_grenadelauncher.h
@@ -70,6 +70,8 @@ public:
 	virtual float GetChargeBeginTime( void );
 	virtual float GetChargeMaxTime( void );
 
+	virtual bool	CanInspect() const OVERRIDE;
+
 	void LaunchGrenade( void );
 
 	void AddDonkVictim( const CBaseEntity* pVictim );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2572,6 +2572,18 @@ void CTFWeaponBase::HandleInspect()
 	// first time pressing inspecting key
 	if ( !m_bInspecting && pPlayer->IsInspecting() )
 	{
+		// Don't inspect while reloading or zooming. TF_COND_ZOOMED for the Classic
+		if ( IsReloading() || pPlayer->m_Shared.InCond( TF_COND_AIMING ) || pPlayer->m_Shared.InCond( TF_COND_ZOOMED ) )
+		{
+			return;
+		}
+		
+		// Don't inspect if the player has just fired
+        	if ( gpGlobals->curtime < m_flNextPrimaryAttack )
+		{
+            		return;
+		}
+		
 		m_nInspectStage = INSPECT_INVALID;
 		m_flInspectAnimEndTime = -1.f;
 		if ( SendWeaponAnim( GetInspectActivity( INSPECT_START ) ) )

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2068,8 +2068,10 @@ bool CTFWeaponBase::ReloadSingly( void )
 	case TF_RELOAD_FINISH:
 	default:
 		{
+			// we create a variable that tracks from curtime to the time + the duration of the finish reload activity
 			if ( SendWeaponAnim( ACT_RELOAD_FINISH ) )
 			{
+				m_flTimeFinishReloadSingly = gpGlobals->curtime + SequenceDuration();
 				// We're done, allow primary attack as soon as we like unless we're an energy weapon.
 //				if ( IsEnergyWeapon() )
 //				{
@@ -2577,11 +2579,17 @@ void CTFWeaponBase::HandleInspect()
 		{
 			return;
 		}
-		
+
 		// Don't inspect if the player has just fired
-        	if ( gpGlobals->curtime < m_flNextPrimaryAttack )
+		if ( gpGlobals->curtime < m_flNextPrimaryAttack )
 		{
-            		return;
+			return;
+		}
+		
+		// Don't inspect if the weapon isn't idle after reloading the last bullet
+		if ( gpGlobals->curtime < m_flTimeFinishReloadSingly )
+		{
+			return;
 		}
 		
 		m_nInspectStage = INSPECT_INVALID;

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -710,6 +710,8 @@ protected:
 	int				m_iLastCritCheckFrame;
 	int				m_iCurrentSeed;
 	float			m_flLastRapidFireCritCheckTime;
+	
+	float			m_flTimeFinishReloadSingly;		// tc2
 
 	float			m_flLastDeployTime;
 	float 			m_flLastReadyTime;


### PR DESCRIPTION
### Related Issue
The first part of https://github.com/ValveSoftware/Source-1-Games/issues/4273

### Implementation
This pr adds some checks to HandleInspect and some specific checks to tf_weapon_flamethrower, tf_weapon_dragons_fury and tf_weapon_grenadelauncher (for the Loose Cannon)

As said in the source issue tracker, a player can inspect when
- reloading. the most annoying of all, it interrupts the reload if the player accidentally inspects
- after firing/deploying, looks weird.
- when zooming with a sniper rifle. it just doesn't make sense
- when charging a cannonball

### Screenshots

pressing F as hard as I can

https://github.com/user-attachments/assets/44c34d5e-2bcd-49f7-95b1-d6ead538ddad

https://github.com/user-attachments/assets/9e7638ae-96b3-45b9-95c6-a1cd67c69ea8

https://github.com/user-attachments/assets/1270b4cc-3d7b-4313-a1d5-0b41a920ba38

https://github.com/user-attachments/assets/830c5907-a365-4811-b472-3af4af94b58f

https://github.com/user-attachments/assets/fbbefffd-3da4-4e04-81ec-829ef40720d4

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/tc2).
- [x] This PR targets the `tc2-mod` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Yep | <!-- Built, Tested or N/A --> | 10    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |

### Caveats
~~When a player has just finished reloading with single reload weapons (shotgun etc) they can still inspect before the animation finishes. I couldn't get to the root and i think i would have to add more code to the reload code. For now i didn't want to do that.~~ FIXED :D
Also, players with the Classic can inspect first and start to charge the gun or zoom. I haven't check how to fix that.
Maybe i could also add a debug convar but whatever

### Alternatives
The checks for TF_COND_AIMING and TF_COND_ZOOMED could be moved to tf_weapon_sniperrifle? I'll check that later, but it works regardless
